### PR TITLE
New or changed sources integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           ARC_MAX_NPM: 10
 
       - name: Test
+        env:
+          CI: true
         run: npm test
 
       # TODO add back everything below!

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -100,3 +100,54 @@ npm run test
 npm run test:unit
 npm run test:integration
 ```
+
+Unit and integration tests are kept separate because the former are
+blazingly fast, while the latter may take some time.
+
+### Unit tests
+
+Run unit tests with `npm run test:unit`
+
+### Integration tests and configuration
+
+Integration tests are in `tests/integration`.
+
+You can run them with `npm run test:integration`
+
+#### `new-or-changed-sources-test.js`
+
+##### Configuration
+
+The test in
+`tests/integration/shared/sources/new-or-changed-sources-test.js` run
+`git diff` for your current branch against some baseline branch.
+
+Since it's impossible for us to accurately guess what the right
+baseline branch would be in your case (`origin/master`?
+`upstream/master`?), you will need to create a `gitdiff.config` in
+`tests/integration/shared/sources`.  See `gitdiff.config.example` in
+that folder for reference.
+
+If this file is missing, the test will stop with a giant warning
+message.  (In CI, we just use `origin/master` as the base branch, and
+this file isn't required).
+
+##### About this test
+
+This test actually runs a live crawl and scrape for any new or changed
+sources (as defined by a `git diff` against the branch you configured
+in `gitdiff.config`).  You'll need to be connected to the net.
+
+##### Running for selected, or all sources
+
+You can tailor the above test by setting some environment variables, e.g.:
+
+```
+# To run _all_ of the sources:
+TEST_ALL=1 npm run test:integration
+
+# To run selected sources:
+TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration
+```
+
+The tests are batched for reasonable execution time.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "scripts": {
     "start": "arc sandbox",
     "lint": "eslint . --ignore-pattern node_modules --fix",
-    "test": "npm run test:unit",
-    "test:unit": "tape 'tests/unit/**/*-test.js' | tap-spec"
+    "test": "tape tests/**/*-test.js | tap-spec",
+    "test:unit": "tape tests/unit/**/*-test.js | tap-spec",
+    "test:integration": "tape tests/integration/**/*-test.js | tap-spec"
   },
   "humans": [
     "This is a serverless monorepo",

--- a/scripts/pause-sandbox
+++ b/scripts/pause-sandbox
@@ -5,8 +5,8 @@
  */
 const fs = require('fs')
 const path = require('path')
-const os = require('os')
-const pauseFile = path.join(os.tmpdir(), '_pause-architect-sandbox-watcher')
+const osPath = require('ospath')
+const pauseFile = path.join(osPath.tmp(), '_pause-architect-sandbox-watcher')
 
 const status = process.env.PAUSE
 

--- a/scripts/pause-sandbox
+++ b/scripts/pause-sandbox
@@ -5,8 +5,8 @@
  */
 const fs = require('fs')
 const path = require('path')
-const osPath = require('ospath')
-const pauseFile = path.join(osPath.tmp(), '_pause-architect-sandbox-watcher')
+const os = require('os')
+const pauseFile = path.join(os.tmpdir(), '_pause-architect-sandbox-watcher')
 
 const status = process.env.PAUSE
 

--- a/src/events/crawler/index.js
+++ b/src/events/crawler/index.js
@@ -5,12 +5,14 @@ const cache = require('./cache')
 
 async function crawlSource (event) {
   try {
-    console.time('Crawl')
     /**
      * Load the requested source
      */
     const source = getSource(event)
     const { scrapers, _sourceKey } = source
+
+    const timeLabel = `Crawl-${_sourceKey}`
+    console.time(timeLabel)
 
     /**
      * Select the current scraper from the source's available scrapers
@@ -60,7 +62,7 @@ async function crawlSource (event) {
      */
     await cache(results)
 
-    console.timeEnd('Crawl')
+    console.timeEnd(timeLabel)
   }
   catch (err) {
     // TODO write something to the database that says this source is offline

--- a/src/events/scraper/index.js
+++ b/src/events/scraper/index.js
@@ -54,7 +54,7 @@ async function scrapeSource (event) {
      */
     const data = normalizeData(source, output, date)
     let { silent } = event
-    if (silent !== true) {
+    if (!silent) {
       // TODO ↓ remove me! ↓
       console.log(`data:`, data)
     }

--- a/src/events/scraper/index.js
+++ b/src/events/scraper/index.js
@@ -11,7 +11,6 @@ const normalizeData = require('./normalize-data/index.js')
 
 async function scrapeSource (event) {
   try {
-    console.time('Scrape')
     let { date } = event
     // Normalize date
     date = date ? datetime.getYYYYMMDD(date) :  datetime.getYYYYMMDD(new Date().toLocaleDateString())
@@ -20,6 +19,10 @@ async function scrapeSource (event) {
      * Load the requested source
      */
     const source = getSource(event)
+
+    const { _sourceKey } = source
+    const timeLabel = `Scrape-${_sourceKey}-${date}`
+    console.time(timeLabel)
 
     /**
      * Get the timezone so we can locale-cast the specified date
@@ -50,13 +53,19 @@ async function scrapeSource (event) {
      * Normalize output
      */
     const data = normalizeData(source, output, date)
-    // TODO ↓ remove me! ↓
-    console.log(`data:`, data)
+    let { silent } = event
+    if (silent !== true) {
+      // TODO ↓ remove me! ↓
+      console.log(`data:`, data)
+    }
 
     // TODO coming soon:
     // await write(data)
+    // TODO: integration test needs to verify that data was written
 
-    console.timeEnd('Scrape')
+    console.timeEnd(timeLabel)
+
+    return data
   }
   catch (err) {
     // TODO write something to the database that says this source is offline

--- a/src/events/scraper/load-cache/_load-local.js
+++ b/src/events/scraper/load-cache/_load-local.js
@@ -3,12 +3,16 @@ const fs = require('fs')
 const { join } = require('path')
 const datetime = require('@architect/shared/datetime/index.js')
 
-let cache = join(__dirname, '..', '..', '..', '..', 'crawler-cache')
-// Alter the local cache dir (handy for such things as integration testing)
-if (process.env.LI_CACHE_PATH) {
-  cache = process.env.LI_CACHE_PATH
+let defaultcache = join(__dirname, '..', '..', '..', '..', 'crawler-cache')
+
+/** Return the default cache path, or LI_CACHE_PATH if set in env. */
+function cachePath(key) {
+  let cache = defaultcache
+  if (process.env.LI_CACHE_PATH) {
+    cache = process.env.LI_CACHE_PATH
+  }
+  return join(cache, key)
 }
-const cachePath = key => join(cache, key)
 
 async function getFolders (_sourceKey) {
   if (!fs.existsSync(cachePath(_sourceKey))) {

--- a/src/shared/sources/_lib/types.js
+++ b/src/shared/sources/_lib/types.js
@@ -1,0 +1,16 @@
+/** List of allowable crawl types. */
+
+// TODO (techdebt): use this in scraper validation.
+const allowedTypes = [
+  'page',
+  'headless',
+  'csv',
+  'tsv',
+  'pdf',
+  'json',
+  'raw'
+]
+
+module.exports = {
+  allowedTypes
+}

--- a/tests/integration/shared/sources/.gitignore
+++ b/tests/integration/shared/sources/.gitignore
@@ -1,0 +1,2 @@
+# Your own personal gitdiff.config file.
+gitdiff.config

--- a/tests/integration/shared/sources/_lib/changed-sources.js
+++ b/tests/integration/shared/sources/_lib/changed-sources.js
@@ -1,0 +1,79 @@
+const path = require('path')
+const fs = require('fs')
+const exec = require('child_process').execSync
+const srcShared = path.join(process.cwd(), 'src', 'shared')
+const sourceMap = require(path.join(srcShared, 'sources', '_lib', 'source-map.js'))
+
+/** Getting changed sources.
+ * For CI, the env variable CI should be set.
+ */
+
+/** Get the proper baseline git remote and branch to diff against.
+*
+* Integration tests sometimes only run against changed sources, so we
+* need to know which branch to compare the current branch to.  In
+* GitHub CI, this is origin/master, but your working env might use a
+* different remote name, and different base branch name.
+*/
+function readConfigFile() {
+  const configFile = path.join(__dirname, '..', 'gitdiff.config')
+  const shortConfig = configFile.replace(process.cwd(), '')
+  if (!fs.existsSync(configFile)) {
+    console.log(`
+*************************************************************
+Missing config file
+ 
+${shortConfig}
+ 
+for integration tests, aborting!
+ 
+This file is necessary to indicate the git remote and branch
+that the code should use to do a 'git diff' against.
+ 
+Please copy the file gitdiff.config.example to gitdiff.config
+and change it to match your personal repo settings.
+*************************************************************`)
+    process.exit()
+  }
+
+  return JSON.parse(fs.readFileSync(configFile))
+}
+
+function getBaseBranch() {
+  let remote = 'origin'
+  let branch = 'master'
+  if (!process.env.CI) {
+    const config = readConfigFile()
+    remote = config.baseRemoteName
+    branch = config.baseBranchName
+    if (remote == null || branch == null)
+      throw new Error(`missing key baseRemoteName or baseBranchName in gitdiff.config`)
+  }
+  return `${remote}/${branch}`
+}
+
+/** Returns array of keys, e.g. ['nyt'] */
+function getChangedSourceKeys() {
+  const b = getBaseBranch()
+
+  // Git diff commands are very strange sometimes: the '...' is
+  // necessary.  See https://stackoverflow.com/questions/20808892/
+  // ("Git diff between current branch and master but not including
+  // unmerged master commits")
+  const command = `git diff --name-only ${b}...`
+
+  const result = exec(command)
+  const filesChanged = result.toString().split('\n')
+
+  const changedKeys = []
+  for (const [key, fname] of Object.entries(sourceMap())) {
+    const s = fname.replace(`${process.cwd()}${path.sep}`, '')
+    if (filesChanged.includes(s))
+      changedKeys.push(key)
+  }
+  return changedKeys
+}
+
+module.exports = {
+  getChangedSourceKeys
+}

--- a/tests/integration/shared/sources/_lib/changed-sources.js
+++ b/tests/integration/shared/sources/_lib/changed-sources.js
@@ -33,28 +33,26 @@ that the code should use to do a 'git diff' against.
 Please copy the file gitdiff.config.example to gitdiff.config
 and change it to match your personal repo settings.
 *************************************************************`)
-    process.exit()
+    process.exit(1)
   }
 
   return JSON.parse(fs.readFileSync(configFile))
 }
 
-function getBaseBranch() {
-  let remote = 'origin'
-  let branch = 'master'
+function getGitDiffBase() {
+  let diffbase = 'origin/master'
   if (!process.env.CI) {
     const config = readConfigFile()
-    remote = config.baseRemoteName
-    branch = config.baseBranchName
-    if (remote == null || branch == null)
-      throw new Error(`missing key baseRemoteName or baseBranchName in gitdiff.config`)
+    diffbase = config.gitDiffBase
+    if (diffbase == null)
+      throw new Error(`missing key gitDiffBase in gitdiff.config`)
   }
-  return `${remote}/${branch}`
+  return diffbase
 }
 
 /** Returns array of keys, e.g. ['nyt'] */
 function getChangedSourceKeys() {
-  const b = getBaseBranch()
+  const b = getGitDiffBase()
 
   // Git diff commands are very strange sometimes: the '...' is
   // necessary.  See https://stackoverflow.com/questions/20808892/

--- a/tests/integration/shared/sources/gitdiff.config.example
+++ b/tests/integration/shared/sources/gitdiff.config.example
@@ -1,0 +1,4 @@
+{
+  "baseRemoteName": "upstream",
+  "baseBranchName": "master"
+}

--- a/tests/integration/shared/sources/gitdiff.config.example
+++ b/tests/integration/shared/sources/gitdiff.config.example
@@ -1,4 +1,19 @@
 {
-  "baseRemoteName": "upstream",
-  "baseBranchName": "master"
+  "comments": [
+    " This file tells _lib/changed-sources.js which base branch to diff       ",
+    " the current branch against when determining what sources have changed.  ",
+
+    " Set the value of 'gitDiffBase' to any branch, e.g.:                     ",
+
+    "  gitDiffBase value           diffs your branch against                  ",
+    "  -----------------           -------------------------                  ",
+    "  'master'                    local master                               ",
+    "  'origin/master'             master of your fork                        ",
+    "  'upstream/master'           covid/li master                            ",
+
+    " (Change the values according to your remote names ...                   ",
+    " run 'git remote -v' to list your remotes and names.)                    "
+  ],
+
+  "gitDiffBase": "upstream/master"
 }

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -185,6 +185,7 @@ test('new or changed sources', async maintest => {
   runBatchedCrawlAndScrape(maintest, batches, today).
     then(result => { console.log(`Got ${result.length} results!`); return result }).
     then(result => testResults(maintest, result))
+  maintest.end()
 })
 
 destroyTestCacheDir()

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -1,0 +1,194 @@
+const path = require('path')
+const fs = require('fs')
+const test = require('tape')
+
+const srcShared = path.join(process.cwd(), 'src', 'shared')
+const datetime = require(path.join(srcShared, 'datetime', 'index.js'))
+const sourceMap = require(path.join(srcShared, 'sources', '_lib', 'source-map.js'))
+const changedSources = require(path.join(__dirname, '_lib', 'changed-sources.js'))
+
+const srcEvents = path.join(process.cwd(), 'src', 'events')
+const crawlerHandler = require(path.join(srcEvents, 'crawler', 'index.js')).handler
+const scraperHandler = require(path.join(srcEvents, 'scraper', 'index.js')).handler
+
+/** Test new or changed scrapers.
+ *
+ * By default, this checks new/changed sources by diffing the current branch
+ * with a baseline branch (see _lib/changed-sources.js).
+ *
+ * You can override this by setting some environment vars:
+ *
+ * TEST_ALL - tests all of the sources
+ * e.g., TEST_ALL=1 npm run test:integration
+ *
+ * TEST_ONLY - a comma-delimited list of sources to test
+ * TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration
+ */
+
+process.env.NODE_ENV = 'testing'
+
+// A fake cache, destroyed and re-created for the test run.
+process.env.LI_CACHE_PATH = path.join(process.cwd(), 'zz-testing-fake-cache')
+
+
+//////////////////////////////////////////////////////////////////////
+// Utilities
+
+/** Split an array into batches, e.g.:
+ * makeBatches([1,2,3,4,5], 3) = [[1,2,3], [4,5]]
+ */
+function makeBatches(arr, batchsize) {
+  const ret = []
+  for (let i = 0; i < arr.length; i += batchsize)
+    ret.push(arr.slice(i, i + batchsize))
+  return ret
+}
+
+/** Runs the full crawl-scrape-save cycle for a given source,
+ * returning a struct indicating which steps succeeded. */
+async function runCrawlAndScrape(key, today) {
+  const result = {
+    key: key,
+    crawled: false,
+    scraped: false,
+    data: null,
+    written: false,
+    success: false,
+    error: null
+  }
+
+  try {
+    const crawlArg = {
+      Records: [
+        { Sns: { Message: JSON.stringify({source: key}) } }
+      ]
+    }
+    console.log(`Calling scrape for ${key}`)
+    await crawlerHandler(crawlArg)
+    result.crawled = true
+
+    const scrapeArg = {
+      Records: [
+        { Sns: { Message: JSON.stringify({source: key, date: today, silent: true}) } }
+      ]
+    }
+    const data = await scraperHandler(scrapeArg)
+    result.scraped = true
+    result.data = data
+
+    // TODO (testing) verify that data was actually written.
+    result.written = true
+
+    result.success = true
+  } catch(err) {
+    console.log(`error: ${err}`)
+    // I tried 'result.error = err' below, but that did not work: the
+    // returned object only contained '"error":{}'.  Changing it to a
+    // string preserved the details.  Not ideal, but not terrible.
+    result.error = `error: ${err}`
+  }
+
+  return result
+}
+
+/** Runs runCrawlAndScrape successively in batches, but run each item
+ * in one batch run in parallel, generating subtests under
+ * maintest. */
+function runBatchedCrawlAndScrape(maintest, batchedKeys, today) {
+  return new Promise(resolve => {
+    var allResults = []
+    var index = 0
+    function runNextBatch() {
+      if (index < batchedKeys.length) {
+        const keys = batchedKeys[index]
+        const comment = `Running ${keys.join(', ')} (batch ${index + 1} of ${batchedKeys.length})`
+        maintest.comment(comment)
+        Promise.all(keys.map(k => runCrawlAndScrape(k, today))).
+          then(results => {
+            allResults = allResults.concat(results)
+            runNextBatch()
+          })
+        index += 1
+      } else {
+        resolve(allResults)
+      }
+    }
+    // start first iteration
+    runNextBatch()
+  })
+}
+
+/** For debugging only. */
+// eslint-disable-next-line no-unused-vars
+function printResults(results) {
+  console.log("Results (minus data):")
+  results.forEach(r => {
+    console.log('------------------------------')
+    let copy = r
+    delete copy.data
+    console.log(JSON.stringify(copy))
+  })
+  return results
+}
+
+/** Check the results. */
+function testResults(maintest, results) {
+  results.forEach (result => {
+    maintest.test(`source: ${result.key}`, t => {
+      t.plan(6)
+      t.ok(result.error === null, `null error "${result.error}"`)
+      t.ok(result.success, 'completed successfully')
+      t.ok(result.crawled, 'crawled')
+      t.ok(result.scraped, 'scraped')
+      t.ok(result.data !== null, 'got data')
+      t.ok(result.written, 'wrote')
+    })
+  })
+  return results
+}
+
+function createTestCacheDir() {
+  const d = process.env.LI_CACHE_PATH
+  if (fs.existsSync(d)) {
+    fs.rmdirSync(d, { recursive: true })
+  }
+  fs.mkdirSync(d)
+}
+
+function destroyTestCacheDir() {
+  const d = process.env.LI_CACHE_PATH
+  if (fs.existsSync(d)) {
+    fs.rmdirSync(d, { recursive: true })
+  }
+}
+
+
+//////////////////////////////////////////////////////////////////////
+// The tests
+
+let sourceKeys = []
+if (process.env.TEST_ALL) {
+  sourceKeys = Object.keys(sourceMap())
+} else if (process.env.TEST_ONLY) {
+  sourceKeys = process.env.TEST_ONLY.split(',')
+} else {
+  sourceKeys = changedSources.getChangedSourceKeys()
+}
+
+const batchSize = 20  // arbitrary.
+const batches = makeBatches(sourceKeys, batchSize)
+
+createTestCacheDir()
+
+test('new or changed sources', async maintest => {
+  const today = datetime.today.utc()
+  runBatchedCrawlAndScrape(maintest, batches, today).
+    then(result => { console.log(`Got ${result.length} results!`); return result }).
+    then(result => testResults(maintest, result))
+})
+
+destroyTestCacheDir()
+
+// TODO (testing) Add fake source that crawls localhost:3000/integrationtest
+// Prior to running test, copy test assets there.
+// Fake source can scrape data like a real scraper, easy and controlled.

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -1,15 +1,14 @@
-const path = require('path')
+const { join } = require('path')
 const fs = require('fs')
 const test = require('tape')
 
-const srcShared = path.join(process.cwd(), 'src', 'shared')
-const datetime = require(path.join(srcShared, 'datetime', 'index.js'))
-const sourceMap = require(path.join(srcShared, 'sources', '_lib', 'source-map.js'))
-const changedSources = require(path.join(__dirname, '_lib', 'changed-sources.js'))
-
-const srcEvents = path.join(process.cwd(), 'src', 'events')
-const crawlerHandler = require(path.join(srcEvents, 'crawler', 'index.js')).handler
-const scraperHandler = require(path.join(srcEvents, 'scraper', 'index.js')).handler
+const srcShared = join(process.cwd(), 'src', 'shared')
+const datetime = require(join(srcShared, 'datetime', 'index.js'))
+const sourceMap = require(join(srcShared, 'sources', '_lib', 'source-map.js'))
+const srcEvents = join(process.cwd(), 'src', 'events')
+const crawlerHandler = require(join(srcEvents, 'crawler', 'index.js')).handler
+const scraperHandler = require(join(srcEvents, 'scraper', 'index.js')).handler
+const changedSources = require(join(__dirname, '_lib', 'changed-sources.js'))
 
 /** Test new or changed scrapers.
  *
@@ -28,7 +27,7 @@ const scraperHandler = require(path.join(srcEvents, 'scraper', 'index.js')).hand
 process.env.NODE_ENV = 'testing'
 
 // A fake cache, destroyed and re-created for the test run.
-process.env.LI_CACHE_PATH = path.join(process.cwd(), 'zz-testing-fake-cache')
+process.env.LI_CACHE_PATH = join(process.cwd(), 'zz-testing-fake-cache')
 
 
 //////////////////////////////////////////////////////////////////////
@@ -52,7 +51,6 @@ async function runCrawlAndScrape(key, today) {
     crawled: false,
     scraped: false,
     data: null,
-    written: false,
     success: false,
     error: null
   }
@@ -75,9 +73,6 @@ async function runCrawlAndScrape(key, today) {
     const data = await scraperHandler(scrapeArg)
     result.scraped = true
     result.data = data
-
-    // TODO (testing) verify that data was actually written.
-    result.written = true
 
     result.success = true
   } catch(err) {
@@ -135,13 +130,12 @@ function printResults(results) {
 function testResults(maintest, results) {
   results.forEach (result => {
     maintest.test(`source: ${result.key}`, t => {
-      t.plan(6)
+      t.plan(5)
       t.ok(result.error === null, `null error "${result.error}"`)
       t.ok(result.success, 'completed successfully')
       t.ok(result.crawled, 'crawled')
       t.ok(result.scraped, 'scraped')
       t.ok(result.data !== null, 'got data')
-      t.ok(result.written, 'wrote')
     })
   })
   return results
@@ -183,7 +177,6 @@ createTestCacheDir()
 test('new or changed sources', async maintest => {
   const today = datetime.today.utc()
   runBatchedCrawlAndScrape(maintest, batches, today).
-    then(result => { console.log(`Got ${result.length} results!`); return result }).
     then(result => testResults(maintest, result))
   maintest.end()
 })

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -100,12 +100,12 @@ function runBatchedCrawlAndScrape(maintest, batchedKeys, today) {
         maintest.comment(comment)
         Promise.all(keys.map(k => runCrawlAndScrape(k, today))).
           then(results => {
-            allResults = allResults.concat(results)
+            allResults.push(results)
             runNextBatch()
           })
         index += 1
       } else {
-        resolve(allResults)
+        resolve(allResults.flat())
       }
     }
     // start first iteration


### PR DESCRIPTION


## Summary

Integration tests for new/changed scrapers.  Addresses part of issue https://github.com/covidatlas/li/issues/3

## Changes

Per the docs/getting_started:

This test actually runs a live crawl and scrape for any new or changed
sources (as defined by a `git diff` against the branch you configured
in `gitdiff.config`).  You'll need to be connected to the net.

You can tailor the above test by setting some environment variables, e.g.:

```
# To run _all_ of the sources:
TEST_ALL=1 npm run test:integration

# To run selected sources:
TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration
```

The tests are batched for reasonable execution time.
