### PR TITLE
fix typo in git clone and add remote upstrem line

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,8 +15,9 @@ First, [fork the repository](https://github.com/covidatlas/li.git) so you're rea
 Replace `yourusername` below with your Github username:
 
 ```
-git clone https://github.com/covidatlas/li.git
+git clone https://github.com/yourusername/li.git
 cd li
+git remote add upstream https://github.com/covidatlas/li.git
 ```
 
 ### 2. Install dependencies


### PR DESCRIPTION

## Changes
Add line to "1. Get Started" in the readme - `docs/getting_started.md`

    typo in git clone
    add remote upstream
