### PR TITLE
Bad cache filename should throw.

### DIFF
--- a/src/events/scraper/load-cache/_get-local-date-from-filename.js
+++ b/src/events/scraper/load-cache/_get-local-date-from-filename.js
@@ -19,6 +19,9 @@ module.exports = function getLocalDateFromFilename (filename, tz='America/Los_An
    */
   file = file.substr(0, 24)
 
+  if (!/\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz]/.test(file))
+    throw new Error(`Bad cache filename ${filename}`)
+
   // Pull out the timestamp
   const ts = convert.filenameToZ8601(file)
 

--- a/tests/unit/events/scraper/load-cache/_get-local-date-from-filename-test.js
+++ b/tests/unit/events/scraper/load-cache/_get-local-date-from-filename-test.js
@@ -1,0 +1,23 @@
+const { join } = require('path')
+const test = require('tape')
+
+const sut = join(process.cwd(), 'src', 'events', 'scraper', 'load-cache', '_get-local-date-from-filename.js')
+const getLocalDateFromFilename = require(sut)
+
+test('Date parsed correctly', t => {
+  const f = join('folder', 'subfolder', '2020-04-11t21_00_00.000z-default-117bb.html.gz')
+  const result = getLocalDateFromFilename(f, 'utc')
+  t.plan(1)
+  t.equal('2020-04-11', result)
+})
+
+test('Bad cache filename throws', t => {
+  const f = join('folder', 'subfolder', 'bad_filename')
+  t.plan(1)
+  try {
+    getLocalDateFromFilename(f, 'utc')
+    t.fail('should have thrown')
+  } catch (err) {
+    t.equal(err.message, 'Bad cache filename folder/subfolder/bad_filename')
+  }
+})


### PR DESCRIPTION
Without the throw, a bad cache filename returns unexpected dates.
