### PR TITLE
Integration scrape all

### DIFF
--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -249,7 +249,7 @@ if (sourceKeys.length === 0) {
   })
 
   // This uses real cache.
-  test.only('New or changed sources, scrape past cache dates', async t => {
+  test('New or changed sources, scrape past cache dates', async t => {
     // List of date folders for each key, e.g.:
     // [ { key: 'gb-eng', date: '2020-04-02'}, {... ]
     const scrapeTests = sourceKeys.map(k => {

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -208,12 +208,11 @@ if (sourceKeys.length === 0) {
     await runBatchedOperation(t, 'crawl', crawls, batchSize)
       .then(results => {
         results.forEach(result => {
-          test(`Crawl source: ${result.key}`, t => {
-            t.plan(2)
-            t.ok(result.success, 'completed successfully')
-            t.ok(result.error === null, `null error "${result.error}"`)
+          t.test(`Crawl source: ${result.key}`, innert => {
+            innert.plan(2)
+            innert.ok(result.success, 'completed successfully')
+            innert.ok(result.error === null, `null error "${result.error}"`)
           })
-          t.pass(`${result.key} ok`)
         })
       })
     delete process.env.LI_CACHE_PATH
@@ -237,13 +236,12 @@ if (sourceKeys.length === 0) {
     await runBatchedOperation(t, 'scrape', scrapes, batchSize)
       .then(results => {
         results.forEach(result => {
-          test(`Scrape source: ${result.key}, today`, t => {
-            t.plan(3)
-            t.ok(result.success, 'completed successfully')
-            t.ok(result.error === null, `null error "${result.error}"`)
-            t.ok(result.data !== null, 'got data')
+          t.test(`Scrape source: ${result.key}, today`, innert => {
+            innert.plan(3)
+            innert.ok(result.success, 'completed successfully')
+            innert.ok(result.error === null, `null error "${result.error}"`)
+            innert.ok(result.data !== null, 'got data')
           })
-          t.pass(`${result.key} ok`)
         })
       })
     delete process.env.LI_CACHE_PATH
@@ -251,7 +249,7 @@ if (sourceKeys.length === 0) {
   })
 
   // This uses real cache.
-  test('New or changed sources, scrape past cache dates', async t => {
+  test.only('New or changed sources, scrape past cache dates', async t => {
     // List of date folders for each key, e.g.:
     // [ { key: 'gb-eng', date: '2020-04-02'}, {... ]
     const scrapeTests = sourceKeys.map(k => {
@@ -268,13 +266,12 @@ if (sourceKeys.length === 0) {
     await runBatchedOperation(t, 'scrape', scrapes, batchSize)
       .then(results => {
         results.forEach(result => {
-          test(`Scrape source: ${result.key}, on ${result.date}`, t => {
-            t.plan(3)
-            t.ok(result.success, 'completed successfully')
-            t.ok(result.error === null, `null error "${result.error}"`)
-            t.ok(result.data !== null, 'got data')
+          t.test(`${result.key} scrape on ${result.date}`, innert => {
+            innert.plan(3)
+            innert.ok(result.success, 'completed successfully')
+            innert.ok(result.error === null, `null error "${result.error}"`)
+            innert.ok(result.data !== null, 'got data')
           })
-          t.pass(`${result.key} ok`)
         })
       })
 

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -6,6 +6,7 @@ const sandbox = require('@architect/sandbox')
 
 const srcShared = join(process.cwd(), 'src', 'shared')
 const datetime = require(join(srcShared, 'datetime', 'index.js'))
+const globJoin = require(join(srcShared, 'utils', 'glob-join.js'))
 const sourceMap = require(join(srcShared, 'sources', '_lib', 'source-map.js'))
 const srcEvents = join(process.cwd(), 'src', 'events')
 const crawlerHandler = require(join(srcEvents, 'crawler', 'index.js')).handler
@@ -75,9 +76,10 @@ async function runCrawl (key, today) {
  */
 function getCacheDatesForSourceKey (key) {
   const cacheRoot = join(__dirname, '..', '..', '..', '..', 'crawler-cache')
-  const folders = glob.sync(join(cacheRoot, key, '*/'))
-  return folders.map(f => f.split(sep)).
-    map(a => a[a.length - 2])
+  const folders = glob.sync(globJoin(cacheRoot, key, '*'))
+  const re = new RegExp(`^.*crawler-cache${sep}${key}${sep}`)
+  const ret = folders.map(f => f.replace(re, ''))
+  return ret
 }
 
 /** Runs scrape for a given source, returning a struct indicating


### PR DESCRIPTION
## Summary

Runs scrape for all dates in the cache, for all new/changed scrapers (or if `TEST_ALL=1 npm run test:integration`, runs all of them), and reports if it was able to scrape successfully.

Sample output:

```
  us-ca-san-francisco-county scrape on 2020-04-08

    ✔ completed successfully
    ✔ null error "null"
    ✔ got data
```

## Changes

* generalized "run batch" method for re-use
* added tests

## Possible future work this may uncover

We may have cases where there are bad files in the cache, and scraping fails.  In fact I think this is likely.  A couple of options:

* fix the scrapers to handle the changed formats at those dates
* remove the files from the cache, or tag them as "invalid", and skip them during scrape runs
* add a list of "known failures" to a text file for the test, so that they're ignored during the test run

