### PR TITLE
Start sandbox on different port for tests.

### DIFF
--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -176,7 +176,11 @@ if (sourceKeys.length === 0) {
     }
     fs.mkdirSync(d)
     t.ok(fs.existsSync(d), 'Created temp directory')
-    await sandbox.start({ quiet: true })
+
+    // By default sandbox is started with port 3333, so specifying the
+    // port here lets the tests run their own sandbox without
+    // colliding with the existing port.
+    await sandbox.start({ port: 5555, quiet: true })
     t.pass('Sandbox started')
   })
 


### PR DESCRIPTION
Fixes error:

```
  TEST_ONLY=nyt npm run test:integration
  (node:69606) UnhandledPromiseRejectionWarning: Error: listen EADDRINUSE: address already in use :::3333
      at Server.setupListenHandle [as _listen2] (net.js:1309:16)
```