### PR TITLE
Throw if no files provided instead of passing along undefined

### DIFF
--- a/src/events/scraper/load-cache/_get-date-bounds.js
+++ b/src/events/scraper/load-cache/_get-date-bounds.js
@@ -5,7 +5,7 @@ const getLocalDateFromFilename = require('./_get-local-date-from-filename.js')
  * Takes a cached filename, returns date boundaries
  */
 module.exports = function getDateBounds (files, tz) {
-  if (files.length === 0) {
+  if (!files || files.length === 0) {
     throw new Error('No files provided')
   }
 

--- a/src/events/scraper/load-cache/_get-date-bounds.js
+++ b/src/events/scraper/load-cache/_get-date-bounds.js
@@ -5,6 +5,10 @@ const getLocalDateFromFilename = require('./_get-local-date-from-filename.js')
  * Takes a cached filename, returns date boundaries
  */
 module.exports = function getDateBounds (files, tz) {
+  if (files.length === 0) {
+    throw new Error('No files provided')
+  }
+
   const sorted = sorter(files) // jic
   const earliest = getLocalDateFromFilename(sorted[0], tz)
   const latest = getLocalDateFromFilename(sorted[sorted.length - 1], tz)


### PR DESCRIPTION
## Summary
Got a whacky error message when no cache was found during a scrape, this will at least throw and stop things from happening.

```
❌ Failed to scrape us-wa:
 SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at getLocalDateFromFilename 
```

Not sure if this is how we want to handle this?
