### PR TITLE
Correctly handle unassigned counties

### DIFF
--- a/src/events/scraper/normalize-data/_normalize-us.js
+++ b/src/events/scraper/normalize-data/_normalize-us.js
@@ -6,8 +6,11 @@ const norm = str => str.replace(/ /g, '').toLowerCase()
 
 // Check if the passed string is unassigned or some variation thereof
 const isUnassigned = county => {
-  county = norm(county)
-  return county === constants.UNASSIGNED || county === 'unknown' || county === 'unassigned'
+  const check = norm(county)
+  const unassigned = check === constants.UNASSIGNED ||
+                     check === 'unassigned' ||
+                     check === 'unknown'
+  return unassigned
 }
 
 module.exports = function lookupFIPS (location) {
@@ -64,6 +67,7 @@ module.exports = function lookupFIPS (location) {
         return stateMatches && countyMatches
       })
 
+      // Unassigned is a special / reserved case
       // These are cases where an impacted individual may not belong to a specific county, but is still counted
       if (isUnassigned(county)) {
         location.county = constants.UNASSIGNED

--- a/src/events/scraper/normalize-data/_normalize-us.js
+++ b/src/events/scraper/normalize-data/_normalize-us.js
@@ -1,7 +1,14 @@
 const usStates = require('@architect/shared/sources/_lib/geography/us-states.json')
+const constants = require('@architect/shared/sources/_lib/constants.js')
 
 // Ensure county name consistency once isolated to a state
 const norm = str => str.replace(/ /g, '').toLowerCase()
+
+// Check if the passed string is unassigned or some variation thereof
+const isUnassigned = county => {
+  county = norm(county)
+  return county === constants.UNASSIGNED || county === 'unknown' || county === 'unassigned'
+}
 
 module.exports = function lookupFIPS (location) {
   const { country, state, county } = location
@@ -58,9 +65,8 @@ module.exports = function lookupFIPS (location) {
       })
 
       // These are cases where an impacted individual may not belong to a specific county, but is still counted
-      // 'unassigned' county is special / reserved
-      if (norm(county) === 'unknown') {
-        location.county = 'unassigned'
+      if (isUnassigned(county)) {
+        location.county = constants.UNASSIGNED
         return location
       }
 

--- a/src/shared/sources/_lib/constants.js
+++ b/src/shared/sources/_lib/constants.js
@@ -1,1 +1,5 @@
-module.exports.UNASSIGNED = '(unassigned)'
+const UNASSIGNED = '(unassigned)'
+
+module.exports = {
+  UNASSIGNED
+}


### PR DESCRIPTION
## Summary

Correctly check if a county is `(unassigned)`, `unknown`, or some other variation that indicates we don't know which county the case is in, don't error if it's passed.

Fixes #28 

Seems to work fine for the `us-wa` branch:
```
  {
    county: '(unassigned)',
    cases: 151,
    deaths: 0,
    country: 'iso1:US',
    state: 'iso2:US-WA',
    location: 'iso1:us#iso2:us-wa#(unassigned)',
    date: '2020-03-19',
    source: 'us-wa',
    priority: 0
  },
```