### PR TITLE
Add `npm run help` to show some info

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -137,3 +137,7 @@ Unit and integration tests are kept separate because the former are
 blazingly fast, while the latter may take some time.
 
 For more info, see [Testing](./docs/testing.md).
+
+## Help
+
+Run `npm run help` to see a list of commands.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "li",
   "version": "0.0.0",
   "scripts": {
+    "help": "node tools/show-help.js",
     "start": "arc sandbox",
     "lint": "eslint . --ignore-pattern node_modules --fix",
     "list-sources": "node src/shared/sources/_lib/list-sources.js",

--- a/tools/list-dev-todos.js
+++ b/tools/list-dev-todos.js
@@ -20,6 +20,11 @@ const glob = require('glob')
 const path = require('path')
 const fs = require('fs')
 
+/** Glob always uses forward slash for separator, regardless of OS. */
+function globJoin (...args) {
+  return path.join(...args).replace(/\\/g, '/')
+}
+
 /** Scan file fname for all FIXME/TODO/etc entries. */
 function scanFile (fname) {
   const content = fs.readFileSync(fname, 'utf-8')
@@ -59,11 +64,15 @@ function printMatches (matches) {
       })
     })
   })
+  console.log(`\n(${matches.length} matches in ${allGroups.length} groups)\n`)
 }
 
-const pattern = path.join(process.cwd(), '**', '*.js')
+const pattern = globJoin(process.cwd(), '**', '*.js')
 const options = {
-  ignore: [ path.join('**', 'node_modules', '**'), path.join('**', 'list-dev-todos.js') ]
+  ignore: [
+    globJoin('**', 'node_modules', '**'),
+    globJoin('**', 'tools', '**')
+  ]
 }
 const matches = []
 glob.sync(pattern, options).forEach(fname => { matches.push(scanFile(fname)) })

--- a/tools/show-help.js
+++ b/tools/show-help.js
@@ -1,0 +1,80 @@
+/** Simple help for the scripts, showing some more text and examples.
+ *
+ * Edit 'descriptions' as new things are added to package.json scripts.
+ */
+
+const path = require('path')
+
+const scripts = require(path.join(__dirname, '..', 'package.json')).scripts
+
+/** Supplemental info. */
+const descriptions = {
+  start: {
+    desc: 'Start the sandbox.',
+    docref: null
+  },
+  lint: {
+    desc: 'Lint and fix js files.',
+    docref: null
+  },
+  'list-sources': {
+    desc: 'List the SourceIDs for all sources.',
+    docref: 'docs/getting_started.md/Source IDs'
+  },
+  todos: {
+    desc: 'List all TODOs, FIXMEs, etc, grouped.',
+    docref: 'TODO'
+  },
+  test: {
+    desc: 'Run all unit and integration tests.',
+    docref: 'docs/testing.md'
+  },
+  'test:unit': {
+    desc: 'Run unit tests.',
+    docref: 'docs/testing.md'
+  },
+  'test:integration': {
+    desc: 'Run integration tests.  Set TEST_ALL or TEST_ONLY env vars to change behaviour',
+    examples: [
+      'To run tests for all sources:',
+      'TEST_ALL=1 npm run test:integration',
+      'To run tests for selected sources:',
+      'TEST_ONLY=gb-sct,gb-eng npm run test:integration'
+    ],
+    docref: 'docs/testing'
+  },
+  migrate: {
+    desc: 'Publish cache items that have been migrated with coronadatascraper/tools/generate-v1-cache.js to AWS.',
+    docref: null
+  },
+  'migration:status': {
+    desc: 'Print summary report of coronadatascraper scraper -> li source migration.',
+    docref: null
+  }
+}
+
+console.log('npm run ...')
+console.log('-----------')
+
+const keys = Object.keys(scripts).sort()
+for (let i = 0; i < keys.length; ++i) {
+  const k = keys[i]
+  const d = descriptions[k]
+  if (!d)
+    continue
+
+  const width = 25
+
+  console.log()
+  const title = [ k, ' '.repeat(width - k.length), d.desc ].join('')
+  console.log(title)
+
+  const indent = ' '.repeat(width)
+  if (d.examples) {
+    console.log(indent + 'EXAMPLES:')
+    d.examples.forEach(e => console.log(indent + e))
+  }
+  if (d.docref)
+    console.log(indent + `SEE: ${d.docref}`)
+}
+


### PR DESCRIPTION
This is yet-another-feature that nobody asked for, but I felt was necessary to help new devs, and sometimes me.

`npm run help` gives the following output:

```
npm run ...
-----------

lint                     Lint and fix js files.

list-sources             List the SourceIDs for all sources.
                         SEE: docs/getting_started.md/Source IDs

migrate                  Publish cache items that have been migrated with coronadatascraper/tools/generate-v1-cache.js to AWS.

start                    Start the sandbox.

test                     Run all unit and integration tests.
                         SEE: docs/testing.md

test:integration         Run integration tests.  Set TEST_ALL or TEST_ONLY env vars to change behaviour
                         EXAMPLES:
                         To run tests for all sources:
                         TEST_ALL=1 npm run test:integration
                         To run tests for selected sources:
                         TEST_ONLY=gb-sct,gb-eng npm run test:integration
                         SEE: docs/testing

test:unit                Run unit tests.
                         SEE: docs/testing.md

todos                    List all TODOs, FIXMEs, etc, grouped.
                         SEE: TODO
```

We can add more by modding the detail in `tools/show-help.js`.