### PR TITLE
Integration test refactor

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,10 +45,21 @@ If this file is missing, the test will stop with a giant warning
 message.  (In CI, we just use `origin/master` as the base branch, and
 this file isn't required).
 
-Note you can ignore the `git diff` by setting some environment variables, e.g.:
+Note you can ignore the `git diff` by setting some environment
+variables, see below.
+
+#### Environment variables.
+
+The integration tests may be insufficient, or too inclusive.  You can
+filter the things to include using some environment variables:
 
 * `TEST_ALL=1 npm run test:integration` runs _all_ of the sources
-* ` TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration` runs the indicated sources
+* `TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration` runs the indicated sources
+* `SCRAPE_ONLY=2020-04-10,2020-04-11 npm run test:integration` only scrapes these dates in the cache
+
+You can combine `TEST_*` and `SCRAPE_ONLY`:
+
+`TEST_ONLY=us-ca-san-francisco-county SCRAPE_ONLY=2020-04-10,2020-04-11 npm run test:integration`
 
 #### Possible errors
 

--- a/tests/integration/shared/sources/new-or-changed-sources-test.js
+++ b/tests/integration/shared/sources/new-or-changed-sources-test.js
@@ -13,7 +13,8 @@ const crawlerHandler = require(join(srcEvents, 'crawler', 'index.js')).handler
 const scraperHandler = require(join(srcEvents, 'scraper', 'index.js')).handler
 const changedSources = require(join(__dirname, '_lib', 'changed-sources.js'))
 
-/** Test new or changed scrapers.
+/**
+ * Test new or changed scrapers.
  *
  * By default, this checks new/changed sources by diffing the current branch
  * with a baseline branch (see _lib/changed-sources.js).
@@ -21,144 +22,30 @@ const changedSources = require(join(__dirname, '_lib', 'changed-sources.js'))
  * You can override this by setting some environment vars:
  *
  * TEST_ALL - tests all of the sources
- * e.g., TEST_ALL=1 npm run test:integration
+ *   eg. TEST_ALL=1 npm run test:integration
  *
  * TEST_ONLY - a comma-delimited list of sources to test
- * TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration
- */
-
-
-//////////////////////////////////////////////////////////////////////
-// Utilities
-
-/** Split an array into batches, e.g.:
- * makeBatches([1,2,3,4,5], 3) = [[1,2,3], [4,5]]
- */
-function makeBatches (arr, batchsize) {
-  const ret = []
-  for (let i = 0; i < arr.length; i += batchsize)
-    ret.push(arr.slice(i, i + batchsize))
-  return ret
-}
-
-/** Runs the crawl for a given source, returning a struct indicating
- * which steps succeeded. */
-async function runCrawl (key, today) {
-  const result = {
-    key: key,
-    success: false,
-    error: null
-  }
-
-  try {
-    const crawlArg = {
-      Records: [
-        { Sns: { Message: JSON.stringify({ source: key, date: today }) } }
-      ]
-    }
-    await crawlerHandler(crawlArg)
-    result.success = true
-  } catch (err) {
-    console.log(`error: ${err}`)
-    // I tried 'result.error = err' below, but that did not work: the
-    // returned object only contained '"error":{}'.  Changing it to a
-    // string preserved the details.  Not ideal, but not terrible.
-    result.error = `error: ${err}`
-  }
-
-  return result
-}
-
-/** Gets the dates for a given source key.
+ *   eg. TEST_ONLY=gb-sct,nl,gb-eng npm run test:integration
  *
- * For example, if the cache only contained crawler-cache/nyt/2020-04-01,
- * this would return ['2020-04-01'].
+ * By default, these tests also try to scrape all cached file dates
+ * for the sources.  You can filter this with SCRAPE_ONLY:
+ *
+ * TEST_ONLY=gb-sct,nl SCRAPE_ONLY=2020-04-10,2020-04-11 npm run test:integration
  */
-function getCacheDatesForSourceKey (key) {
-  const cacheRoot = join(__dirname, '..', '..', '..', '..', 'crawler-cache')
-  const folders = glob.sync(globJoin(cacheRoot, key, '*'))
-  const re = new RegExp(`^.*crawler-cache${sep}${key}${sep}`)
-  const ret = folders.map(f => f.replace(re, ''))
-  return ret
-}
 
-/** Runs scrape for a given source, returning a struct indicating
- * which steps succeeded. */
-async function runScrape (key, dt) {
-  const result = {
-    key: key,
-    date: dt,
-    success: false,
-    error: null,
-    data: null
-  }
+/** If any test failed, refer devs to docs/testing.md. */
+let failcount = 0
+test.onFailure(() => { failcount++ })
 
-  try {
-    const scrapeArg = {
-      Records: [
-        { Sns: { Message: JSON.stringify({ source: key, date: dt, silent: true }) } }
-      ]
-    }
-    const data = await scraperHandler(scrapeArg)
-    result.data = data
-    result.success = true
-  } catch (err) {
-    console.log(`error: ${err}`)
-    // I tried 'result.error = err' below, but that did not work: the
-    // returned object only contained '"error":{}'.  Changing it to a
-    // string preserved the details.  Not ideal, but not terrible.
-    result.error = `error: ${err}`
-  }
+process.env.NODE_ENV = 'testing'
 
-  return result
-}
+/** A fake cache, destroyed and re-created for the test run. */
+const testingCache = join(process.cwd(), 'zz-testing-fake-cache')
 
-
-/** Runs operation successively in batches, but run each item
- * in one batch run in parallel, generating subtests under
- * maintest. */
-function runBatchedOperation (maintest, opname, operations, batchSize) {
-  const batchedOperations = makeBatches(operations, batchSize)
-  return new Promise(resolve => {
-    var allResults = []
-    var index = 0
-    function runNextBatch () {
-      if (index < batchedOperations.length) {
-        const ops = batchedOperations[index]
-        const batchmsg = `batch ${index + 1} of ${batchedOperations.length}`
-        const comment = `${opname} (${batchmsg})`
-        maintest.comment(comment)
-        Promise.all(ops.map(o => o.execute())).
-          then(results => {
-            allResults.push(results)
-            runNextBatch()
-          })
-        index += 1
-      } else {
-        resolve(allResults.flat())
-      }
-    }
-    // start first iteration
-    runNextBatch()
-  })
-}
-
-/** For debugging only. */
-// eslint-disable-next-line no-unused-vars
-function printResults (results) {
-  console.log("Results (minus data):")
-  results.forEach(r => {
-    console.log('------------------------------')
-    let copy = r
-    delete copy.data
-    console.log(JSON.stringify(copy))
-  })
-  return results
-}
-
-//////////////////////////////////////////////////////////////////////
-// The tests
-
+/** By default sandbox is started with port 3333, so specifying the
+ * port here lets the tests run their own sandbox without colliding
+ * with the existing port. */
+const sandboxPort = 5555
 
 let sourceKeys = []
 if (process.env.TEST_ALL) {
@@ -173,20 +60,8 @@ if (sourceKeys.length === 0) {
   test('No changed sources', t => {
     t.plan(1); t.pass('hooray!')
   })
-  // This return will exit this test module.
-  return
+  return  // exits this module.
 }
-
-// If any test failed, refer devs to docs/testing.md.
-let showFailureAdvice = false
-test.onFailure(() => { showFailureAdvice = true })
-
-const batchSize = 20  // arbitrary.
-
-process.env.NODE_ENV = 'testing'
-
-// A fake cache, destroyed and re-created for the test run.
-const testingCache = join(process.cwd(), 'zz-testing-fake-cache')
 
 test('Setup', async t => {
   t.plan(2)
@@ -196,108 +71,109 @@ test('Setup', async t => {
   fs.mkdirSync(testingCache)
   t.ok(fs.existsSync(testingCache), 'Created temp directory')
 
-  // If this isn't set local auth breaks.
-  process.env.CRAWL_TOKEN = 'testing'
-
-  // By default sandbox is started with port 3333, so specifying the
-  // port here lets the tests run their own sandbox without
-  // colliding with the existing port.
-  await sandbox.start({ port: 5555, quiet: true })
+  await sandbox.start({ port: sandboxPort, quiet: true })
   t.pass('Sandbox started')
 })
 
-function createCrawlCall (key) {
-  return {
-    name: key,
-    execute: () => { return runCrawl(key) }
-  }
+function makeEventMessage (hsh) {
+  return { Records: [ { Sns: { Message: JSON.stringify(hsh) } } ] }
 }
 
-test('Live crawl, new or changed sources', async t => {
+test('Live crawl', async t => {
   process.env.LI_CACHE_PATH = testingCache
   t.plan(sourceKeys.length + 1)
-  const crawls = sourceKeys.map(k => createCrawlCall(k))
-  // TODO look into how we can clean up the parallelization
-  await runBatchedOperation(t, 'Live crawl', crawls, batchSize)
-    .then(results => {
-      results.forEach(result => {
-        t.test(`Live crawl: ${result.key}`, innert => {
-          innert.plan(2)
-          innert.ok(result.success, 'completed successfully')
-          innert.ok(result.error === null, `null error "${result.error}"`)
-        })
-      })
-    })
+  const today = datetime.today.utc()
+  for (const key of sourceKeys) {
+    try {
+      await crawlerHandler(makeEventMessage({ source: key, date: today }))
+      t.ok(`${key} succeeded`)
+    } catch (err) {
+      t.fail(`${key} failed: ${err}`)
+    }
+  }
   delete process.env.LI_CACHE_PATH
   t.ok(process.env.LI_CACHE_PATH === undefined, 'no LI_CACHE_PATH')
 })
-
-function createScrapeCall (key, date) {
-  return {
-    name: `${key} for ${date}`,
-    execute: () => { return runScrape (key, date) }
-  }
-}
 
 // Note: this test assumes that the testingCache contains data!
-test('Live scrape, new or changed sources', async t => {
-  process.env.LI_CACHE_PATH = testingCache
-  const today = datetime.today.utc()
+test('Live scrape', async t => {
   t.plan(sourceKeys.length + 1)
-  const scrapes = sourceKeys.map(k => createScrapeCall(k, today))
-  // TODO look into how we can clean up the parallelization
-  await runBatchedOperation(t, 'Live scrape', scrapes, batchSize)
-    .then(results => {
-      results.forEach(result => {
-        t.test(`Live scrape: ${result.key}, today`, innert => {
-          innert.plan(3)
-          innert.ok(result.success, 'completed successfully')
-          innert.ok(result.error === null, `null error "${result.error}"`)
-          innert.ok(result.data !== null, 'got data')
-        })
-      })
-    })
+  const today = datetime.today.utc()
+  for (const key of sourceKeys) {
+    try {
+      const arg = makeEventMessage({ source: key, date: today, silent: true })
+      const data = await scraperHandler(arg)
+      // TODO (testing): verify the returned data struct conforms to schema.
+      t.ok(`${key} succeeded (${data.length} record${data.length > 1 ? 's' : ''})`)
+    } catch (err) {
+      t.fail(`${key} failed: ${err}`)
+    }
+  }
   delete process.env.LI_CACHE_PATH
   t.ok(process.env.LI_CACHE_PATH === undefined, 'no LI_CACHE_PATH')
 })
 
-// This uses real cache.
-test('Historical scrape, new or changed sources', async t => {
-  // List of date folders for each key, e.g.:
-  // [ { key: 'gb-eng', date: '2020-04-02'}, {... ]
-  const scrapeTests = sourceKeys.map(k => {
-    return getCacheDatesForSourceKey(k).
-      map(dt => { return { key: k, date: dt } })
-  }).flat()
-
-  t.plan(scrapeTests.length + 2)  // +1 cache dir check, +1 final pass
-  t.ok(process.env.LI_CACHE_PATH === undefined, 'using real cache')
-
-  const scrapes = scrapeTests.map(st => createScrapeCall(st.key, st.date))
-
-  // TODO look into how we can clean up the parallelization
-  await runBatchedOperation(t, 'Historical scrape', scrapes, batchSize)
-    .then(results => {
-      results.forEach(result => {
-        t.test(`Historical scrape: ${result.key} scrape on ${result.date}`, innert => {
-          innert.plan(3)
-          innert.ok(result.success, 'completed successfully')
-          innert.ok(result.error === null, `null error "${result.error}"`)
-          innert.ok(result.data !== null, 'got data')
-        })
+/**
+ * List of { key, cacheDate } entries for the entire cache, so we can
+ * ensure they're scrapable.
+ *
+ * For example, if the cache only contained
+ * crawler-cache/nyt/2020-04-01, this would return:
+ *   [ { key: 'nyt', cacheDate: '2020-04-01' } ]
+ */
+const cacheRoot = join(__dirname, '..', '..', '..', '..', 'crawler-cache')
+const scrapeDates = process.env.SCRAPE_ONLY ? process.env.SCRAPE_ONLY.split(',') : []
+const historicalScrapeTests = glob.sync(globJoin(cacheRoot, '*', '*')).
+      map(s => { return s.replace(cacheRoot + sep, '') }).
+      map(s => {
+        const [ key, cacheDate ] = s.split(sep)
+        return { key, cacheDate }
+      }).
+      filter(hsh => sourceKeys.includes(hsh.key)).
+      filter(hsh => {
+        return (scrapeDates.length > 0 ? scrapeDates.includes(hsh.cacheDate) : true)
       })
-    })
 
+// This uses real cache.
+test('Historical scrape', async t => {
+  t.plan(historicalScrapeTests.length + 2)  // +1 cache dir check, +1 final pass
+  t.ok(process.env.LI_CACHE_PATH === undefined, 'using real cache')
+  for (const hsh of historicalScrapeTests) {
+    const testname = `${hsh.key} cache scrape ${hsh.cacheDate}`
+    try {
+      const arg = makeEventMessage({ source: hsh.key, date: hsh.cacheDate, silent: true })
+      const data = await scraperHandler(arg)
+      // TODO (testing): verify the returned data struct conforms to schema.
+      t.ok(true, `${testname} succeeded (${data.length} record${data.length > 1 ? 's' : ''})`)
+    } catch (err) {
+      t.fail(`${testname} failed: ${err}`)
+    }
+  }
   t.pass('ok')
 })
 
 test('Teardown', async t => {
+  /** architect sandbox uses an internal server to handle events,
+   * listening to the sandbox port + 1 (see
+   * https://github.com/architect/sandbox/blob/master/src/sandbox/index.js,
+   * search for 'process.env.ARC_EVENTS_PORT').  If the sandbox is
+   * closed and events are still pending, ECONNREFUSED is thrown.  If
+   * unhandled, this crashes the Node process, including tape, so we'll
+   * ignore just these errors for the sake of testing. */
+  process.on('uncaughtException', err => {
+    if (err.message === `connect ECONNREFUSED 127.0.0.1:${sandboxPort + 1}`) {
+      console.error('(Ignoring sandbox exception thrown during integration test Teardown)')
+    }
+    else
+      throw err
+  })
+
   t.plan(2)
   if (fs.existsSync(testingCache)) {
     fs.rmdirSync(testingCache, { recursive: true })
   }
   t.notOk(fs.existsSync(testingCache), 'Removed temp directory')
-  delete process.env.CRAWL_TOKEN
+
   await sandbox.end()
   t.pass('Sandbox closed')
 })
@@ -306,13 +182,8 @@ test('Teardown', async t => {
 // Prior to running test, copy test assets there.
 // Fake source can scrape data like a real scraper, easy and controlled.
 
-
 // If any test failed, refer devs to docs/testing.md.
-test('New or changed sources test summary', t => {
+test('Summary', t => {
   t.plan(1)
-  if (showFailureAdvice) {
-    t.fail('Some integration tests failed.  See docs/testing.md for how to handle them')
-  } else {
-    t.ok(true, 'All tests passed')
-  }
+  t.equal(0, failcount, `${failcount} integration tests failed.  See docs/testing.md for how to handle them`)
 })


### PR DESCRIPTION
## Summary

* Rewrote integration tests to be sequential only
* Added note to docs re `SCRAPE_ONLY` env setting

The error that we were getting on the parallelized runs was due to the internal architect sandbox events server shutting down, so I added a (well-commented) hack to teardown to handle that error.