### PR TITLE
Fallback to tasks0 when last invoke can't be found inside scheduled runner

### DIFF
--- a/src/scheduled/runner/find-invoke/index.js
+++ b/src/scheduled/runner/find-invoke/index.js
@@ -18,7 +18,7 @@ module.exports = async function findNextInvoke () {
   const timestamps = invokes.map(i => i.lastInvoke)
   const sorted = sorter(timestamps)
   const last = invokes.find(i => i.lastInvoke === sorted[0])
-  const task = last.key
+  const task = last ? last.key : tasks[0]
 
   await data.invokes.put({
     type,

--- a/src/scheduled/runner/find-invoke/index.js
+++ b/src/scheduled/runner/find-invoke/index.js
@@ -13,18 +13,12 @@ module.exports = async function findNextInvoke () {
   invokes = invokes.Items.filter(i => i.type === type)
 
   const tasks = [ 'crawler', 'scraper' ]
-  let task
-
-  // Add entries for the new kids
-  if (invokes.length) {
-    task = tasks[0]
-  }
 
   // This will likely need to be rewritten if the task runner ever takes on more than just crawling and scraping
   const timestamps = invokes.map(i => i.lastInvoke)
   const sorted = sorter(timestamps)
   const last = invokes.find(i => i.lastInvoke === sorted[0])
-  task = last.key
+  const task = last.key
 
   await data.invokes.put({
     type,


### PR DESCRIPTION
Found using LGTM tool

https://lgtm.com/projects/g/covidatlas/li/snapshot/dc74ebe972f94a7685a6acaeefa6293c2d24a886/files/src/scheduled/runner/find-invoke/index.js#x80a7b2ff2d1692c1:1

We assigned then always reassigned so the first bit does nothing. Yay code deletion opportunity.