### PR TITLE
Clean test tap output, add info to failure messages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "lint": "eslint . --ignore-pattern node_modules --fix",
     "list-sources": "node src/shared/sources/_lib/list-sources.js",
     "todos": "node tools/list-dev-todos.js",
-    "test": "tape tests/**/*-test.js | tap-spec",
-    "test:unit": "tape tests/unit/**/*-test.js | tap-spec",
-    "test:integration": "tape tests/integration/**/*-test.js | tap-spec",
+    "test": "tape tests/**/*-test.js | node tools/clean-tap-output.js | tap-spec",
+    "test:unit": "tape tests/unit/**/*-test.js | node tools/clean-tap-output.js | tap-spec",
+    "test:integration": "tape tests/integration/**/*-test.js | node tools/clean-tap-output.js | tap-spec",
     "migrate:latest": "./tools/migrate-latest-cache",
     "migrate:publish": "AWS_PROFILE=covidatlas ./tools/publish-migrated-cache",
     "migration:status": "node tools/report-migration-status.js"

--- a/tools/clean-tap-output.js
+++ b/tools/clean-tap-output.js
@@ -12,7 +12,7 @@ function printFailureSummary (failureLines) {
     operator: /^ {4}operator: (.*)/,
     expected: /^ {4}expected: (.*)/,
     actual: /^ {4}actual: (.*)/,
-    at: /^ {4}at: .*?\/li\/(tests\/.*)\)/
+    at: /^ {4}at: .*?\/(tests\/.*)\)/
   }
 
   const hsh = {}

--- a/tools/clean-tap-output.js
+++ b/tools/clean-tap-output.js
@@ -1,0 +1,114 @@
+/** Clean up tap output and make it quicker to find problems.
+ *
+ * Reads from stdin.
+ */
+
+var readline = require('readline')
+
+/** Add failure details to the first line of the failure summary. */
+function printFailureSummary (failureLines) {
+
+  const partREs = {
+    operator: /^ {4}operator: (.*)/,
+    expected: /^ {4}expected: (.*)/,
+    actual: /^ {4}actual: (.*)/,
+    at: /^ {4}at: .*?\/li\/(tests\/.*)\)/
+  }
+
+  const hsh = {}
+  for (const [ key, re ] of Object.entries(partREs)) {
+    const m = getMatch(failureLines, re)
+    if (m) {
+      hsh[key] = m.trim()
+    }
+  }
+  // Truncate long things.
+  const maxLen = 20
+  if (hsh.expected && hsh.expected.length > maxLen)
+    hsh.abbreviated = true
+  if (hsh.actual && hsh.actual.length > maxLen)
+    hsh.abbreviated = true
+  // console.log(hsh)
+
+  let append = []
+  if (hsh.abbreviated && hsh.operator) {
+    append.push(`expected not ${hsh.operator} actual (see log)`)
+  }
+  if (hsh.expected && hsh.actual && hsh.operator) {
+    append.push(`${hsh.expected} not ${hsh.operator} ${hsh.actual}`)
+  } else if (hsh.operator) {
+    append.push(hsh.operator)
+  }
+  append.push(`at: ${hsh.at}`)
+
+  // Write the failing test and some more detail.
+  let msg = `${failureLines[0]} (${append.join(' ')})`
+  console.log(msg)
+
+  // Write useful stack trace lines.
+  const condensed = failureLines.slice(1).filter(s => { return !excludeLine(s) })
+  condensed.forEach(c => console.log(c))
+}
+
+/** Exclude some lines from test summary. */
+function excludeLine (line) {
+  const excludes = [
+    /^ {10}at Test\..*?node_modules.*/,
+    /^ {10}at Immediate.next /,
+    /^ {10}at processImmediate/
+  ]
+
+  for (var i = 0; i < excludes.length; i++) {
+    if (line.match(excludes[i])) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Given array of lines and a regex, returns match group 1 of the
+ * first line matching it, or null. */
+function getMatch (lines, re) {
+  for (var i = 0; i < lines.length; i++) {
+    const m = lines[i].match(re)
+    if (m)
+      return m[1]
+  }
+  return null
+}
+
+/**
+ * Main.
+ */
+
+/** Reader of stdin */
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+})
+
+/** Current state of input (cheap finite state machine). */
+let currState = 'ok'
+
+/** Buffer of lines collected when in 'not-ok' state. */
+let testFailure = []
+
+rl.on('line', function (line) {
+  // State transition.
+  if (/^not ok/.test(line))
+    currState = 'not-ok'
+  if (line === '  ...' && currState === 'not-ok')
+    currState = 'ok'
+
+  if (currState === 'not-ok') {
+    testFailure.push(line)
+  }
+  if (currState === 'ok') {
+    if (testFailure.length > 0) {
+      printFailureSummary(testFailure)
+      testFailure = []
+    }
+    console.log(line)
+  }
+})


### PR DESCRIPTION
This change makes the TAP test failure summary a bit more useful, don't have to scroll through tons of log lines!

Before this change, npm test failures (tap-spec) summary looks like this (with fake test failures):

```
Failed Tests: There were 2 failures

    Module exists

      x whatever


    Generate some filenames

      x Month matches
```

After this change, it looks like this:

```
Failed Tests: There were 2 failures

    Module exists

      x whatever (fail at: tests/unit/crawler/cache/_cache-namer-test.js:14:5)


    Generate some filenames

      x Month matches ('05x' not equal '05' at: tests/unit/crawler/cache/_cache-namer-test.js:45:5)
```