### PR TITLE
Handle live crawl fails as test warnings only.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sam.json
 sam.yaml
 scratch/
 tools/geojsondb/geojson-db-payload.json
+test-results.txt

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "lint": "eslint . --ignore-pattern node_modules --fix",
     "list-sources": "node src/shared/sources/_lib/list-sources.js",
     "todos": "node tools/list-dev-todos.js",
-    "test": "tape tests/**/*-test.js | node tools/clean-tap-output.js | tap-spec",
-    "test:unit": "tape tests/unit/**/*-test.js | node tools/clean-tap-output.js | tap-spec",
-    "test:integration": "tape tests/integration/**/*-test.js | node tools/clean-tap-output.js | tap-spec",
+    "test": "tape tests/**/*-test.js | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
+    "test:unit": "tape tests/unit/**/*-test.js | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
+    "test:integration": "tape tests/integration/**/*-test.js | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
     "migrate:latest": "./tools/migrate-latest-cache",
     "migrate:publish": "AWS_PROFILE=covidatlas ./tools/publish-migrated-cache",
     "migration:status": "node tools/report-migration-status.js"

--- a/src/shared/sources/ru/index.js
+++ b/src/shared/sources/ru/index.js
@@ -42,7 +42,8 @@ module.exports = {
         const ruEntries = $.data.items.filter(({ ru }) => ru)
 
         const states = ruEntries.map(({ name, cases, cured: recovered, deaths }) => ({
-          // The slugify latinized names are quite different from the official latinizations so can't use getIso2FromName.
+          // The slugify latinized names are quite different from the
+          // official latinizations so can't use getIso2FromName.
 
           // The list contains data at federal subject level, which is the top-level political
           // divisions (including cities of Moscow and St Petersburg).

--- a/tests/save-test-results.js
+++ b/tests/save-test-results.js
@@ -1,0 +1,25 @@
+/** Save the test results to an ignored file for later checking. */
+
+var readline = require('readline')
+var path = require('path')
+var fs = require('fs')
+
+const testFile = path.join(process.cwd(), 'test-results.txt')
+
+fs.writeFileSync(testFile, `Test results as at ${new Date()}\n`)
+
+/**
+ * Main.
+ */
+
+/** Reader of stdin */
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+})
+
+rl.on('line', function (line) {
+  fs.writeFileSync(testFile, `${line}\n`, { flag: 'a' })
+  console.log(line)
+})

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -239,13 +239,10 @@ test('Scraper validation test', t => {
     }
   }
 
+  // Print warnings.
   if (warnings.length) {
-    setTimeout(() => {
-      console.warn('')
-      console.warn('⚠️  Warnings!')
-      for (const warn of warnings) {
-        console.warn(warn)
-      }
-    }, 100)
+    for (const warn of warnings) {
+      console.log('Warning: ' + warn)
+    }
   }
 })

--- a/tests/warnings.js
+++ b/tests/warnings.js
@@ -1,0 +1,18 @@
+/** Print any test warnings to console. */
+
+var path = require('path')
+var fs = require('fs')
+
+const testFile = path.join(process.cwd(), 'test-results.txt')
+const data = fs.readFileSync(testFile, 'utf-8')
+
+const warnings = data.split('\n').filter(s => s.match(/^warning/i))
+
+if (warnings.length > 0) {
+  console.warn('\n------------------------------------------------------------\n')
+  console.warn(`⚠️  ${warnings.length} Warnings:`)
+  for (const warn of warnings) {
+    console.warn(' ' + warn)
+  }
+  console.warn('')
+}


### PR DESCRIPTION
## Summary

Handle crawl fails as warnings.

If the crawl succeeds, but the scrape fails, this is still treated as a failure.

### Prior to this change

Live crawl failures made CI fail:

```
$ TEST_ONLY=gb-eng npm run test
...

  Failed Tests: There were 3 failures

    Live crawl

      ✖ gb-eng failed: Error: Crawl returned status code: 403 Type: csv (normal) Params: { "type": "csv", "url": "https://www.arcgis.com/sharing/rest/content/items/b684319181f94875a6879bbc833ca3a6/data" } (fail at: tests/integration/shared/sources/new-or-changed-sources-test.js:89:9)


    Live scrape

      ✖ gb-eng failed: Error: Could not load cache; cache not available locally or in S3 (fail at: tests/integration/shared/sources/new-or-changed-sources-test.js:107:9)

```

This is no good.

### With this change

Crawls that fail just warn:

```
$ TEST_ONLY=gb-eng npm run test
...


  total:     204
  passing:   204
  duration:  5.7s



------------------------------------------------------------

⚠️  5 Warnings:
 Warning: Live gb-eng crawl failed: Error: Crawl returned status code: 403
 Warning: Source gb-eng: Missing maintainers, please list one or more!
 Warning: Source gb-sct: Missing maintainers, please list one or more!
 Warning: Source nyt: Missing maintainers, please list one or more!
 Warning: Source us-ut: Missing maintainers, please list one or more!
```


This also leaves a 'test-results.txt' in project root, ignored by git, which is used to generate the Warnings list at the end of everything.