### PR TITLE
[patch] fix IN adding more states to table

### DIFF
--- a/src/shared/sources/au/au-from-wa-health/index.js
+++ b/src/shared/sources/au/au-from-wa-health/index.js
@@ -66,7 +66,7 @@ module.exports = {
 
         const indexForCases = dataKeysByColumnIndex.findIndex(key => key === 'cases')
         const casesFromTotalRow = parse.number(
-          normalizedTable.find(row => row.some(column => column === 'Total'))[indexForCases]
+          normalizedTable.find(row => row.some(cell => cell === 'Total'))[indexForCases]
         )
         assertTotalsAreReasonable({ computed: summedData.cases, scraped: casesFromTotalRow })
         return states

--- a/src/shared/sources/au/index.js
+++ b/src/shared/sources/au/index.js
@@ -66,7 +66,7 @@ module.exports = {
 
         const indexForCases = dataKeysByColumnIndex.findIndex(key => key === 'cases')
         const casesFromTotalRow = parse.number(
-          normalizedTable.find((row) => row.some(column => column === 'Total'))[indexForCases]
+          normalizedTable.find((row) => row.some(cell => cell === 'Total'))[indexForCases]
         )
         assertTotalsAreReasonable({ computed: summedData.cases, scraped: casesFromTotalRow })
         return states
@@ -122,7 +122,7 @@ module.exports = {
 
         const indexForCases = dataKeysByColumnIndex.findIndex(key => key === 'cases')
         const casesFromTotalRow = parse.number(
-          normalizedTable.find((row) => row.some(column => column === totalLabel))[indexForCases]
+          normalizedTable.find((row) => row.some(cell => cell === totalLabel))[indexForCases]
         )
         assertTotalsAreReasonable({ computed: summedData.cases, scraped: casesFromTotalRow })
         return states

--- a/src/shared/sources/in/index.js
+++ b/src/shared/sources/in/index.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const maintainers = require('../_lib/maintainers.js')
 const parse = require('../_lib/parse.js')
 const transform = require('../_lib/transform.js')
@@ -42,10 +41,7 @@ module.exports = {
         })
 
         // Create new array with just the state data (no headings, comments, totals)
-        const stateDataRows = normalizedTable.slice(1, 33)
-
-        const statesCount = 32
-        assert.equal(stateDataRows.length, statesCount, 'Wrong number of rows found')
+        const stateDataRows = normalizedTable.filter(row => row[0].match(/\d/))
 
         const states = []
         stateDataRows.forEach((row) => {
@@ -56,7 +52,11 @@ module.exports = {
           })
 
           states.push({
-            state: getIso2FromName({ country, name: stateData.state.replace('Telengana', 'Telangana') }),
+            state: getIso2FromName({
+              country, name: stateData.state
+                .replace('Telengana', 'Telangana')
+                .replace('Dadar Nagar Haveli', 'Dadra and Nagar Haveli')
+            }),
             cases: parse.number(stateData.cases),
             deaths: parse.number(stateData.deaths),
             recovered: parse.number(stateData.recovered)
@@ -69,7 +69,7 @@ module.exports = {
         const indexForCases = dataKeysByColumnIndex.findIndex(key => key === 'cases')
         const casesFromTotalRow = parse.number(
           normalizedTable.find(
-            row => row.some(column => column === 'Total number of confirmed cases in India')
+            row => row.some(cell => cell === 'Total number of confirmed cases in India')
           )[indexForCases]
         )
         assertTotalsAreReasonable({ computed: summedData.cases, scraped: casesFromTotalRow })

--- a/src/shared/sources/kr/index.js
+++ b/src/shared/sources/kr/index.js
@@ -75,7 +75,7 @@ module.exports = {
 
         const indexForCases = dataKeysByColumnIndex.findIndex(key => key === 'cases')
         const casesFromTotalRow = parse.number(
-          normalizedTable.find(row => row.some(column => column === 'Total'))[indexForCases]
+          normalizedTable.find(row => row.some(cell => cell === 'Total'))[indexForCases]
         )
         assertTotalsAreReasonable({ computed: summedData.cases, scraped: casesFromTotalRow })
         return states

--- a/src/shared/sources/nz/index.js
+++ b/src/shared/sources/nz/index.js
@@ -90,7 +90,7 @@ module.exports = {
         const indexForCases = dataKeysByColumnIndex.findIndex(key => key === 'cases')
         const tableWithoutHeadingRow = normalizedTable.slice(1)
         const casesFromTotalRow = parse.number(
-          tableWithoutHeadingRow.find(row => row.some(column => column === 'Total'))[indexForCases]
+          tableWithoutHeadingRow.find(row => row.some(cell => cell === 'Total'))[indexForCases]
         )
         assertTotalsAreReasonable({ computed: summedData.cases, scraped: casesFromTotalRow })
         return states


### PR DESCRIPTION
## Summary
Their first cell in rows with state data are just a sequential number, so lets pattern match on those. Added state is pretty different than in iso2, so hard code replace it.