### PR TITLE
Quote glob paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "lint": "eslint . --ignore-pattern node_modules --fix",
     "list-sources": "node src/shared/sources/_lib/list-sources.js",
     "todos": "node tools/list-dev-todos.js",
-    "test": "tape tests/**/*-test.js | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
-    "test:unit": "tape tests/unit/**/*-test.js | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
-    "test:integration": "tape tests/integration/**/*-test.js | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
+    "test": "tape 'tests/**/*-test.js' | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
+    "test:unit": "tape 'tests/unit/**/*-test.js' | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
+    "test:integration": "tape 'tests/integration/**/*-test.js' | node tests/save-test-results.js | node tools/clean-tap-output.js | tap-spec; node tests/warnings.js",
     "migrate:latest": "./tools/migrate-latest-cache",
     "migrate:publish": "AWS_PROFILE=covidatlas ./tools/publish-migrated-cache",
     "migration:status": "node tools/report-migration-status.js"


### PR DESCRIPTION
Without this, tape does not find all test files accurately.
