### PR TITLE
Fix datetime parse.

### DIFF
--- a/src/shared/datetime/_parse.js
+++ b/src/shared/datetime/_parse.js
@@ -21,7 +21,7 @@ module.exports = function parse (date) {
   // String
   if (typeof date === 'string') {
     const str = truncate(normalize(date))
-    const s = spacetime(str)
+    const s = spacetime(str, 'UTC')
 
     // ISO date
     if (looksLike.isoDate(str)) {
@@ -29,27 +29,27 @@ module.exports = function parse (date) {
     }
 
     // YYYY-M-D
-    if (looksLike.YYYYMD(str)) {
+    if (looksLike.YYYYMD(str) || looksLike.YYYYMMDD(str)) {
       const [ y, m, d ] = str.split('-').map(Number) // e.g. [2020, 3, 16]
-      return spacetime([ y, m - 1, d ]).format('iso-short')
+      return spacetime([ y, m - 1, d ], 'UTC').format('iso-short')
     }
 
     // M-D-YYYY
     if (looksLike.MDYYYY(str)) {
       const [ m, d, yyyy ] = str.split('-').map(Number) // e.g. [3, 16, 2020]
-      return spacetime([ yyyy, m - 1, d ]).format('iso-short')
+      return spacetime([ yyyy, m - 1, d ], 'UTC').format('iso-short')
     }
 
     // M-D-YY
     if (looksLike.MDYY(str)) {
       const [ m, d, yy ] = str.split('-').map(Number) // e.g. [3, 16, 20]
       const yyyy = yy + 2000 // assume current century
-      return spacetime([ yyyy, m - 1, d ]).format('iso-short')
+      return spacetime([ yyyy, m - 1, d ], 'UTC').format('iso-short')
     }
 
     // 0: Treat zero as the beginning of unix epoch
     if (s === '0') {
-      return spacetime([ 1970, 1, 1 ]).format('iso-short')
+      return spacetime([ 1970, 1, 1 ], 'UTC').format('iso-short')
     }
 
     // last chance - try using js Date


### PR DESCRIPTION
Currently, depending on timezone, parse of a string can return a different date.  e.g, parse "2020-03-01" may return "2020-03-02", depending on timezone.