### PR TITLE
Proposal: console.table scraped data

### DIFF
--- a/src/events/scraper/_scrape.js
+++ b/src/events/scraper/_scrape.js
@@ -59,7 +59,7 @@ module.exports = async function scrape (event) {
      * Normalize output
      */
     const data = normalizeData(source, output, date)
-
+    console.table(data)
     console.timeEnd(timeLabel)
 
     return data


### PR DESCRIPTION
I always find myself adding a console.table before returning the data while developing sources.

I'm wondering if we should just add this line so the console shows:
<!-- You can erase any parts of this template if they're not applicable.  Cheers! -->
<img width="865" alt="image" src="https://user-images.githubusercontent.com/4197647/81796274-8f296b00-9550-11ea-829a-a09ab7d3c185.png">

There may be noise/negative ramifications, so putting this up as more of a proposal (obviously I can add this line for myself locally, just wanted to see if it'd help other folks).