### PR TITLE
Rename source crawler "data" property to "format"

### DIFF
--- a/docs/sample-sources/sample.js
+++ b/docs/sample-sources/sample.js
@@ -102,11 +102,13 @@ module.exports = {
       crawl: [
         {
           type: 'page',
+          format: 'paragraph',
           url: 'https://someotherdata-cases.html',
           name: 'cases'
         },
         {
           type: 'page',
+          format: 'table',
           url: 'https://someotherdata-deaths.html',
           name: 'deaths'
         }

--- a/src/shared/sources/au/act/index.js
+++ b/src/shared/sources/au/act/index.js
@@ -24,7 +24,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.health.act.gov.au/about-our-health-system/novel-coronavirus-covid-19'
         }
       ],
@@ -53,7 +53,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.covid19.act.gov.au/updates/confirmed-case-information'
         }
       ],
@@ -89,7 +89,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.covid19.act.gov.au'
         }
       ],

--- a/src/shared/sources/au/index.js
+++ b/src/shared/sources/au/index.js
@@ -27,7 +27,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url:
             'https://www.health.gov.au/news/health-alerts/novel-coronavirus-2019-ncov-health-alert/coronavirus-covid-19-current-situation-and-case-numbers'
         }
@@ -78,7 +78,7 @@ module.exports = {
         {
           type: 'headless',
           timeout: 15000,
-          data: 'table',
+          format: 'table',
           url: 'https://www.health.gov.au/resources/total-covid-19-cases-and-deaths-by-states-and-territories'
         }
       ],

--- a/src/shared/sources/au/nsw/index.js
+++ b/src/shared/sources/au/nsw/index.js
@@ -22,7 +22,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: async (client) => {
             const rssFeed = 'https://www.health.nsw.gov.au/_layouts/feed.aspx?xsl=1&web=/news&page=4ac47e14-04a9-4016-b501-65a23280e841&wp=baabf81e-a904-44f1-8d59-5f6d56519965&pageurl=/news/Pages/rss-nsw-health.aspx'
             const { body } = await client({ url: rssFeed })

--- a/src/shared/sources/au/nt/index.js
+++ b/src/shared/sources/au/nt/index.js
@@ -23,7 +23,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://coronavirus.nt.gov.au/'
         }
       ],

--- a/src/shared/sources/au/qld/index.js
+++ b/src/shared/sources/au/qld/index.js
@@ -25,7 +25,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: async (client) => {
             const { body } = await client({ url: 'https://www.health.qld.gov.au/news-events/doh-media-releases' })
             const matches = body.match(

--- a/src/shared/sources/au/sa/index.js
+++ b/src/shared/sources/au/sa/index.js
@@ -46,7 +46,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'paragraph',
+          format: 'paragraph',
           url: firstUrl
         }
       ],
@@ -63,7 +63,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: () => {
             if (datetime.dateIsBeforeOrEqualTo(datetime.cast(null, 'Australia/Adelaide'), '2020-04-21')) {
               return { url: firstUrl }

--- a/src/shared/sources/au/tas/index.js
+++ b/src/shared/sources/au/tas/index.js
@@ -26,7 +26,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.coronavirus.tas.gov.au/facts/cases-and-testing-updates'
         }
       ],

--- a/src/shared/sources/au/vic/index.js
+++ b/src/shared/sources/au/vic/index.js
@@ -31,7 +31,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'paragraph',
+          format: 'paragraph',
           url: async (client) => {
             const { body } = await client({ url: 'https://www.dhhs.vic.gov.au/media-hub-coronavirus-disease-covid-19' })
             const matches = body.match(

--- a/src/shared/sources/gb/sct/index.js
+++ b/src/shared/sources/gb/sct/index.js
@@ -32,7 +32,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.gov.scot/coronavirus-covid-19/'
         }
       ],
@@ -72,7 +72,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.gov.scot/coronavirus-covid-19/'
         }
       ],

--- a/src/shared/sources/id/index.js
+++ b/src/shared/sources/id/index.js
@@ -25,7 +25,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.kemkes.go.id/'
         }
       ],

--- a/src/shared/sources/in/index.js
+++ b/src/shared/sources/in/index.js
@@ -26,7 +26,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url:
             'https://www.mohfw.gov.in/'
         }

--- a/src/shared/sources/kr/index.js
+++ b/src/shared/sources/kr/index.js
@@ -33,7 +33,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url:
             'http://ncov.mohw.go.kr/en/bdBoardList.do?brdId=16&brdGubun=162&dataGubun=&ncvContSeq=&contSeq=&board_id='
         }

--- a/src/shared/sources/my/index.js
+++ b/src/shared/sources/my/index.js
@@ -27,7 +27,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://www.moh.gov.my/index.php/pages/view/2019-ncov-wuhan'
         },
       ],

--- a/src/shared/sources/nz/index.js
+++ b/src/shared/sources/nz/index.js
@@ -48,7 +48,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url:
             'https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-current-situation/covid-19-current-cases'
         }

--- a/src/shared/sources/pr/index.js
+++ b/src/shared/sources/pr/index.js
@@ -27,7 +27,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'http://www.salud.gov.pr/Pages/coronavirus.aspx'
         }
       ],

--- a/src/shared/sources/us/ca/san-francisco-county.js
+++ b/src/shared/sources/us/ca/san-francisco-county.js
@@ -16,7 +16,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'paragraph',
+          format: 'paragraph',
           url: 'https://www.sfdph.org/dph/alerts/coronavirus.asp'
         }
       ],

--- a/src/shared/sources/us/ut/index.js
+++ b/src/shared/sources/us/ut/index.js
@@ -14,7 +14,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://coronavirus.utah.gov/latest/'
         }
       ],
@@ -44,7 +44,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://coronavirus-dashboard.utah.gov/'
         }
       ],
@@ -82,7 +82,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'table',
+          format: 'table',
           url: 'https://coronavirus-dashboard.utah.gov/'
         }
       ],

--- a/src/shared/sources/vi/index.js
+++ b/src/shared/sources/vi/index.js
@@ -17,7 +17,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'paragraph',
+          format: 'paragraph',
           url:
             'https://doh.vi.gov/covid19usvi'
         }
@@ -63,7 +63,7 @@ module.exports = {
       crawl: [
         {
           type: 'page',
-          data: 'paragraph',
+          format: 'paragraph',
           url:
             'https://doh.vi.gov/covid19usvi'
         }

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -78,7 +78,7 @@ function validateSource (source) {
     // Ok, now let's go into the crawler(s)
     let crawlerNames = {}
     for (const crawler of crawl) {
-      const { type, data, url, timeout } = crawler
+      const { type, format, url, timeout } = crawler
 
       // Crawl type
       requirement(allowed.some(a => a === type), datedError(
@@ -86,7 +86,7 @@ function validateSource (source) {
       ))
 
       // Crawl data format type (for ranking I guess?)
-      requirement(is.string(data) || !data, datedError('Crawler data must be a string'))
+      requirement(is.string(format) || !format, datedError('Crawler format must be a string'))
 
       // Crawl URL
       requirement(is.string(url) || is.function(url), datedError('Crawler url must be a string or function'))

--- a/tools/gen-raw-files.js
+++ b/tools/gen-raw-files.js
@@ -248,7 +248,7 @@ async function getSourceData (key, map, date) {
     _path: srcPath,
     url: baseUrl,
     scraperTz: tz,
-    type: scraper.crawl[0].data, // Used in CDS for ratings.
+    type: scraper.crawl[0].format, // Used in CDS for ratings.
   }
 
   if (source.friendly)


### PR DESCRIPTION
## Summary

Rename property only:

```
      crawl: [
        {
          type: 'page',
          data: 'table',    <<<<<   Becomes "format: 'table',"
          url: 'https://www.kemkes.go.id/'
        }
```

## Reason for rename

* When Li does a crawl and scrape, it actually assigns the returned data from the crawl to `data`, so that would overwrite the existing `data` value, which will be used when calculating ratings.  I felt that changing the scrapers would be better than changing the core code.
* `format` feels like a better name for the field.