### PR TITLE
Change returned crawler 'data' property to 'content'.

### DIFF
--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -87,7 +87,7 @@ async function load (params, useS3) {
       // - attempting to scrape this file, and if it doesn't work, trying a previous scrape from the same day?
       const file = matches[matches.length - 1]
 
-      crawl.data = await loader.getFileContents({ _sourceKey, keys, file })
+      crawl.content = await loader.getFileContents({ _sourceKey, keys, file })
       cache.push(crawl)
     }
     if (cache !== 'miss') {

--- a/src/events/scraper/parse-cache/index.js
+++ b/src/events/scraper/parse-cache/index.js
@@ -19,15 +19,15 @@ module.exports = async function parseCache (cache, date) {
 
   const parsed = []
   for (const hit of cache) {
-    let { data } = hit
+    let { content } = hit
     // Convert non-binaries out of the buffer
     let result
     if (hit.type !== 'pdf') {
-      data = data.toString()
-      result = parse[hit.type]({ data, date })
+      content = content.toString()
+      result = parse[hit.type]({ content, date })
     }
     else {
-      result = await parse[hit.type]({ data, date })
+      result = await parse[hit.type]({ content, date })
     }
     const name = hit.name || 'default'
     parsed.push({ [name]: result })

--- a/src/events/scraper/parse-cache/types/csv.js
+++ b/src/events/scraper/parse-cache/types/csv.js
@@ -7,8 +7,8 @@ const csvParse = require('csv-parse/lib/sync')
  *  - delimiter: the delimiter to use (default is ,)
  */
 module.exports = function csv (params) {
-  const { data, options={} } = params
-  return csvParse(data, {
+  const { content, options={} } = params
+  return csvParse(content, {
     delimiter: options.delimiter,
     columns: true
   })

--- a/src/events/scraper/parse-cache/types/json.js
+++ b/src/events/scraper/parse-cache/types/json.js
@@ -3,6 +3,6 @@
  * @param {*} data the JSON payload to parse
  */
 module.exports = function json (params) {
-  const { data } = params
-  return JSON.parse(data)
+  const { content } = params
+  return JSON.parse(content)
 }

--- a/src/events/scraper/parse-cache/types/page.js
+++ b/src/events/scraper/parse-cache/types/page.js
@@ -5,6 +5,6 @@ const cheerio = require('cheerio')
  * @param {*} data the CSV payload to parse
  */
 module.exports = function page (params) {
-  const { data } = params
-  return cheerio.load(data)
+  const { content } = params
+  return cheerio.load(content)
 }

--- a/src/events/scraper/parse-cache/types/pdf.js
+++ b/src/events/scraper/parse-cache/types/pdf.js
@@ -12,12 +12,12 @@ const PDFParser = require('pdf2json')
  * - page: the page number this element is situated in
  */
 module.exports = async function parsePDF (params) {
-  const { data } = params
+  const { content } = params
 
   return new Promise((resolve, reject) => {
     const parser = new PDFParser()
 
-    parser.parseBuffer(data)
+    parser.parseBuffer(content)
     parser.on('pdfParser_dataError', err => reject(err.parserError))
     parser.on('pdfParser_dataReady', pdfData => {
       const parsed = []

--- a/src/events/scraper/parse-cache/types/raw.js
+++ b/src/events/scraper/parse-cache/types/raw.js
@@ -3,7 +3,7 @@
  * @param {*} data
  */
 module.exports = function json (params) {
-  const { data } = params
+  const { content } = params
   // toString probably not necessary but do it jic to guard against upstream changes
-  return data.toString('utf8')
+  return content.toString('utf8')
 }

--- a/src/events/scraper/parse-cache/types/tsv.js
+++ b/src/events/scraper/parse-cache/types/tsv.js
@@ -5,7 +5,7 @@ const csv = require('./csv.js')
  * @param {*} data the TSV payload to parse
  */
 module.exports = function tsv (params) {
-  const { data } = params
+  const { content } = params
   const options = { delimiter: '\t' }
-  return csv({ data, options })
+  return csv({ content, options })
 }


### PR DESCRIPTION
The sources already have a crawler field called `data` which we shouldn't overwrite.  Using a new field called `content` instead.