### PR TITLE
refactor getIso2 util to align sources handling of iso2 lookups

### DIFF
--- a/src/events/scraper/run-scraper/scraper-helpers/get-iso2-from-name.js
+++ b/src/events/scraper/run-scraper/scraper-helpers/get-iso2-from-name.js
@@ -12,22 +12,39 @@ slugify.extend({ 'ō': 'o' })
  * Find ISO2 code within a country.
  * Guarantees non-ambiguous match (to avoid New York "City" or "State" problem).
  * @param {object} options - Options.
+ * @param {object} options.isoMap - Ambiguous items, mapped directly to their iso2 values
+ *   ({'Australian Capital Territory: 'iso2:AU-ACT'}). Use when > 1 match.
+ * @param {object} options.nameToCanonical - Non canonical names mapped to canonical names
+ *   ({'Aust. Capital Territory: 'Australian Capital Territory'}). Use when 0 match.
  * @param {string} options.country - The iso1 country code to match within (iso1:AU)
  * @param {string} options.name - The name to look up ("Australian Capital Territory")
  * @returns {string} - The iso2 ID ('iso2:AU-ACT').
  */
 module.exports = function getIso2FromName (params) {
-  const { country, name } = params
-  const iso2WithinIso1 = Object.values(iso2).filter(item => item.iso2.startsWith(country.replace('iso1:', '')))
-  if (name === UNASSIGNED) {
-    return `iso2:${name}`
+  const { isoMap, nameToCanonical, country, name } = params
+  const countryCode = country.replace('iso1:', '')
+  const iso2WithinIso1 = Object.values(iso2).filter(item => item.iso2.startsWith(countryCode))
+  const nameForMatching = (nameToCanonical || {})[name] || name
+
+  if (nameForMatching === UNASSIGNED) {
+    return `iso2:${UNASSIGNED}`
   }
-  const slugName = slugify(name, slugifyOptions)
+
+  const hardCodedIso2 = (isoMap || {})[name]
+  if (hardCodedIso2 && hardCodedIso2.startsWith(`iso2:${countryCode}`)) {
+    return hardCodedIso2
+  }
+
+  const slugName = slugify(nameForMatching, slugifyOptions)
   const foundItems = iso2WithinIso1.filter(
     (canonicalItem) => slugify(canonicalItem.name, slugifyOptions).includes(slugName)
   )
+  assert.notEqual(foundItems.length, 0,
+    `No match found for ${name} in ${country}. Use 'nameToCanonical' option to map ${name} to UNASSIGNED or one of the names at https://github.com/hyperknot/country-levels-export/blob/master/docs/iso2_list/${countryCode.toUpperCase()}.md`
+  )
+
   assert.equal(foundItems.length, 1,
-    `No single match found for ${name} in ${country}. Found ${iso2WithinIso1.map((item) => item.name).join()}`
+    `Multiple (${foundItems.length}) matches found for ${name} in ${country}. Use 'isoMap' option to map ${name} to one of the ISO2 values at https://github.com/hyperknot/country-levels-export/blob/master/docs/iso2_list/${countryCode.toUpperCase()}.md `
   )
   return foundItems[0].countrylevel_id
 }

--- a/src/shared/sources/ca/index.js
+++ b/src/shared/sources/ca/index.js
@@ -7,7 +7,11 @@ const { UNASSIGNED } = require('../_lib/constants.js')
 
 const country = 'iso1:CA'
 
-const parseOrUndefined = (value) =>value ? parse.number(value) : undefined
+const parseOrUndefined = (value) => value ? parse.number(value) : undefined
+
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Repatriated travellers': UNASSIGNED
+}
 
 module.exports = {
   aggregate: 'state',
@@ -33,7 +37,7 @@ module.exports = {
           .filter(row => row.date === datetime.getDDMMYYYY(date))
           .filter(row => 'Canada' !== row.prname)
           .map(row => ({
-            state: getIso2FromName({ country, name: row.prname.replace('Repatriated travellers', UNASSIGNED) }),
+            state: getIso2FromName({ country, name: row.prname, nameToCanonical }),
             cases: parseOrUndefined(row.numconf),
             deaths: parseOrUndefined(row.numdeaths),
             recovered: parseOrUndefined(row.numrecover),

--- a/src/shared/sources/cn/index.js
+++ b/src/shared/sources/cn/index.js
@@ -40,7 +40,7 @@ module.exports = {
         assert(attributes.length > 0, 'data fetch failed, no attributes')
 
         const states = attributes.map(item => ({
-          state: getIso2FromName({ country, name: latinizationMap[item.name] }),
+          state: getIso2FromName({ country, name: item.name, nameToCanonical: latinizationMap }),
           cases: item[casesKey],
           deaths: item[deathsKey]
         }))

--- a/src/shared/sources/ie/index.js
+++ b/src/shared/sources/ie/index.js
@@ -6,6 +6,10 @@ const parse = require('../_lib/parse.js')
 
 const country = 'iso1:IE'
 
+const isoMap = { // Non-unique gets mapped straight to ISO2
+  'Meath': 'iso2:IE-MH',
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -25,27 +29,20 @@ module.exports = {
         }
       ],
       scrape ($, date, { getIso2FromName }) {
-        const getIso2IE = (name) => {
-          const isoOverrides = { // Non-unique gets mapped straight to ISO2
-            'Meath': 'iso2:IE-MH',
-          }
-          return isoOverrides[name] || getIso2FromName({ country, name })
-        }
-
-        const casesByRegion = {}
+        const casesByState = {}
 
         for (const item of $) {
           const itemDate = datetime.parse(item['﻿TimeStamp'].replace(/\//g, '-'))
           if (itemDate === date) {
-            casesByRegion[item.CountyName] = parse.number(item.ConfirmedCovidCases)
+            casesByState[item.CountyName] = parse.number(item.ConfirmedCovidCases)
           }
         }
 
         const states = []
-        for (const stateName of Object.keys(casesByRegion)) {
+        for (const stateName of Object.keys(casesByState)) {
           states.push({
-            state: getIso2IE(stateName),
-            cases: casesByRegion[stateName]
+            state: getIso2FromName({ country, name: stateName, isoMap }),
+            cases: casesByState[stateName]
           })
         }
 

--- a/src/shared/sources/in/index.js
+++ b/src/shared/sources/in/index.js
@@ -12,6 +12,11 @@ const schemaKeysByHeadingFragment = {
   's. no.': null,
 }
 
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Telengana': 'Telangana',
+  'Dadar Nagar Haveli': 'Dadra and Nagar Haveli',
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -52,11 +57,7 @@ module.exports = {
           })
 
           states.push({
-            state: getIso2FromName({
-              country, name: stateData.state
-                .replace('Telengana', 'Telangana')
-                .replace('Dadar Nagar Haveli', 'Dadra and Nagar Haveli')
-            }),
+            state: getIso2FromName({ country, name: stateData.state, nameToCanonical }),
             cases: parse.number(stateData.cases),
             deaths: parse.number(stateData.deaths),
             recovered: parse.number(stateData.recovered)

--- a/src/shared/sources/it/index.js
+++ b/src/shared/sources/it/index.js
@@ -7,6 +7,21 @@ const { UNASSIGNED } = require('../_lib/constants.js')
 
 const country = 'iso1:IT'
 
+const isoMap = { // Non-unique gets mapped straight to ISO2
+  'Calabria': 'iso2:IT-78',
+  'Lombardia': 'iso2:IT-25',
+  'P.A. Trento': 'iso2:IT-32',
+  'Piemonte': 'iso2:IT-21',
+  'Puglia': 'iso2:IT-75',
+  'Sicilia': 'iso2:IT-82',
+  'Toscana': 'iso2:IT-52',
+  "Valle d'Aosta": 'iso2:IT-23',
+}
+
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'P.A. Bolzano': UNASSIGNED,
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -26,27 +41,10 @@ module.exports = {
         }
       ],
       scrape ($, date, { getIso2FromName }) {
-
-        const getIso2IT = (name) => {
-          const overrides = {
-            'Calabria' : 'iso2:IT-78',
-            'Lombardia' : 'iso2:IT-25',
-            'P.A. Bolzano' : UNASSIGNED,
-            'P.A. Trento' : 'iso2:IT-32',
-            'Piemonte' : 'iso2:IT-21',
-            'Puglia' : 'iso2:IT-75',
-            'Sicilia' : 'iso2:IT-82',
-            'Toscana' : 'iso2:IT-52',
-            "Valle d'Aosta" : 'iso2:IT-23',
-          }
-
-          return overrides[name] || getIso2FromName({ country, name })
-        }
-
         const states = $
           .filter(row => row.data.substr(0, 10) === datetime.getYYYYMMDD(date))
           .map(row => ({
-            state: getIso2IT(row.denominazione_regione),
+            state: getIso2FromName({ country, name: row.denominazione_regione, isoMap, nameToCanonical }),
             cases: parse.number(row.totale_casi),
             deaths: parse.number(row.deceduti),
             recovered: parse.number(row.dimessi_guariti),

--- a/src/shared/sources/kr/index.js
+++ b/src/shared/sources/kr/index.js
@@ -18,6 +18,10 @@ const schemaKeysByHeadingFragment = {
   'released from quarantine': 'recovered',
 }
 
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Lazaretto': UNASSIGNED
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -63,7 +67,7 @@ module.exports = {
           })
 
           states.push({
-            state: getIso2FromName({ country, name: stateData.state.replace('Lazaretto', UNASSIGNED) }),
+            state: getIso2FromName({ country, name: stateData.state, nameToCanonical }),
             cases: parse.number(stateData.cases.replace('-', 0)),
             deaths: parse.number(stateData.deaths),
             recovered: parse.number(stateData.recovered)

--- a/src/shared/sources/lv/index.js
+++ b/src/shared/sources/lv/index.js
@@ -3,6 +3,19 @@ const maintainers = require('../_lib/maintainers.js')
 const transform = require('../_lib/transform.js')
 
 const country = 'iso1:LV'
+const isoMap = { // Non-unique gets mapped straight to ISO2
+  'Ventspils': 'iso2:LV-VEN',
+  'Jelgava': 'iso2:LV-JEL',
+  'Rēzekne': 'iso2:LV-REZ',
+  'Jēkabpils': 'iso2:LV-JKB',
+  'Jelgavas novads': 'iso2:LV-041',
+  'Daugavpils': 'iso2:LV-DGV',
+}
+
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  "Cēsu novads": "Cēsis county",
+  "Mazsalacas novads": "Mazsalaca county",
+}
 
 module.exports = {
   aggregate: 'state',
@@ -24,23 +37,6 @@ module.exports = {
         }
       ],
       scrape ($, date, { getIso2FromName }) {
-        const getIso2LV = (name) => {
-          const isoOverrides = { // Non-unique gets mapped straight to ISO2
-            'Ventspils': 'iso2:LV-VEN',
-            'Jelgava': 'iso2:LV-JEL',
-            'Rēzekne': 'iso2:LV-REZ',
-            'Jēkabpils': 'iso2:LV-JKB',
-            'Jelgavas novads': 'iso2:LV-041',
-            'Daugavpils': 'iso2:LV-DGV',
-          }
-
-          const nameOverrides = { // Name differences get mapped to the canonical names
-            "Cēsu novads": "Cēsis county",
-            "Mazsalacas novads": "Mazsalaca county",
-          }
-
-          return isoOverrides[name] || getIso2FromName({ country, name: nameOverrides[name] || name })
-        }
         assert($.features.length > 0, 'features are unreasonable')
         const attributes = $.features.map(({ attributes }) => attributes)
 
@@ -49,7 +45,7 @@ module.exports = {
         const states = []
         attributes.forEach((attribute) => {
           states.push({
-            state: getIso2LV(attribute.Nos_pilns),
+            state: getIso2FromName({ country, name: attribute.Nos_pilns, isoMap, nameToCanonical }),
             cases: attribute.Covid_sasl,
           })
         })

--- a/src/shared/sources/mm/index.js
+++ b/src/shared/sources/mm/index.js
@@ -4,6 +4,11 @@ const transform = require('../_lib/transform.js')
 
 const country = 'iso1:MM'
 
+const isoMap = { // Non-unique gets mapped straight to ISO2
+  'Chin':'iso2:MM-14',
+  'Mangway':'iso2:MM-03',
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -32,14 +37,10 @@ module.exports = {
         const getIso2FromNameForMM = (nameRaw) => {
           const parentheticalRegex = / \(\w+\)/
           const name = nameRaw.replace(parentheticalRegex, '').replace(' State', '').replace(' Region', '')
-          if (name === 'Chin') {
-            return 'iso2:MM-14'
-          }
-          if (name === 'Mangway') {
-            return 'iso2:MM-03'
-          }
-          return getIso2FromName({ country, name })
+
+          return getIso2FromName({ country, name, isoMap })
         }
+
         const groupedByState = groupBy(attributes, attribute => getIso2FromNameForMM(attribute.SR))
         const states = []
 

--- a/src/shared/sources/ng/index.js
+++ b/src/shared/sources/ng/index.js
@@ -4,6 +4,10 @@ const transform = require('../_lib/transform.js')
 
 const country = 'iso1:NG'
 
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Nassarawa': 'Nasarawa'
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -33,7 +37,7 @@ module.exports = {
         const states = []
         attributes.forEach((attribute) => {
           states.push({
-            state: getIso2FromName({ country, name: attribute.NAME_1.replace('Nassarawa', 'Nasarawa') }),
+            state: getIso2FromName({ country, name: attribute.NAME_1, nameToCanonical }),
             active: attribute.Active_Cases,
             cases: attribute.ConfCases,
             deaths: attribute.Deaths,

--- a/src/shared/sources/nz/index.js
+++ b/src/shared/sources/nz/index.js
@@ -15,23 +15,18 @@ const schemaKeysByHeadingFragment = {
   dhb: 'state'
 }
 
-const getNamesThatMatchIso2s = name => {
-  if ([
-    'Capital and Coast',
-    'Counties Manukau',
-    'Hutt Valley',
-    'Lakes',
-    'Mid Central',
-    'Nelson Marlborough',
-    'South Canterbury',
-    'Southern',
-    'Tairāwhiti',
-    'Wairarapa',
-    'Waitematā'
-  ].includes(name)) {
-    return UNASSIGNED
-  }
-  return name
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Capital and Coast': UNASSIGNED,
+  'Counties Manukau': UNASSIGNED,
+  'Hutt Valley': UNASSIGNED,
+  'Lakes': UNASSIGNED,
+  'Mid Central': UNASSIGNED,
+  'Nelson Marlborough': UNASSIGNED,
+  'South Canterbury': UNASSIGNED,
+  'Southern': UNASSIGNED,
+  'Tairāwhiti': UNASSIGNED,
+  'Wairarapa': UNASSIGNED,
+  'Waitematā': UNASSIGNED
 }
 
 module.exports = {
@@ -74,9 +69,8 @@ module.exports = {
             const key = dataKeysByColumnIndex[columnIndex]
             stateData[key] = value
           })
-          const stateName = getNamesThatMatchIso2s(stateData.state)
           states.push({
-            state: getIso2FromName({ country, name: stateName }),
+            state: getIso2FromName({ country, name: stateData.state, nameToCanonical }),
             cases: parse.number(stateData.cases),
             deaths: parse.number(stateData.deaths),
             recovered: parse.number(stateData.recovered)

--- a/src/shared/sources/sa/index.js
+++ b/src/shared/sources/sa/index.js
@@ -6,6 +6,13 @@ const country = 'iso1:SA'
 
 const sum = (items) => items.map(stateAttribute => stateAttribute.cases).reduce((a, b) => a + b, 0)
 
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Mecca': 'Makka',
+  'Medina': 'Madinah',
+  'Hail': 'Hayel',
+  'Jouf': 'Jawf',
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -41,12 +48,7 @@ module.exports = {
         for (const [ stateName, stateAttributes ] of Object.entries(groupedByState)) {
           if (stateName !== 'Total') {
             states.push({
-              state: getIso2FromName({ country, name: stateName
-                .replace('Mecca', 'Makka')
-                .replace('Medina', 'Madinah')
-                .replace('Hail', 'Hayel')
-                .replace('Jouf', 'Jawf')
-              }),
+              state: getIso2FromName({ country, name: stateName, nameToCanonical }),
               cases: sum(stateAttributes.filter(stateAttribute => stateAttribute.indicator === 'Cases')),
               active: sum(stateAttributes.filter(stateAttribute => stateAttribute.indicator === 'Active cases')),
               recovered: sum(stateAttributes.filter(stateAttribute => stateAttribute.indicator === 'Recoveries')),

--- a/src/shared/sources/se/index.js
+++ b/src/shared/sources/se/index.js
@@ -21,6 +21,14 @@ const nonStateKeys = [
   icuKey,
 ]
 
+const isoMap = { // Non-unique gets mapped straight to ISO2
+  'Gotland': 'iso2:SE-I',
+}
+
+const nameToCanonical = { // Name differences get mapped to the canonical names
+  'Dalarna': 'Dalecarlia',
+}
+
 module.exports = {
   aggregate: 'state',
   country,
@@ -59,15 +67,8 @@ module.exports = {
         const states = []
         for (const [ key, value ] of Object.entries(cumulatedObject)) {
           if (!nonStateKeys.includes(key)) {
-            const overrides = {
-              'Gotland': 'iso2:SE-I',
-            }
             states.push({
-              state: overrides[key] || getIso2FromName({
-                country, name: key
-                  .replace('_', ' ')
-                  .replace('Dalarna', 'Dalecarlia')
-              }),
+              state: getIso2FromName({ country, name: key.replace('_', ' '), isoMap, nameToCanonical }),
               cases: value
             })
           }

--- a/src/shared/sources/ua/index.js
+++ b/src/shared/sources/ua/index.js
@@ -2,9 +2,15 @@ const assert = require('assert')
 const datetime = require('../../datetime/index.js')
 const maintainers = require('../_lib/maintainers.js')
 const parse = require('../_lib/parse.js')
-const transform = require('../_lib/transform.js'
-)
+const transform = require('../_lib/transform.js')
+
 const country = `iso1:UA`
+
+const isoMap = { // Non-unique gets mapped straight to ISO2
+  'Kyiv': 'iso2:UA-30',
+  'Kyivska': 'iso2:UA-32',
+  'Chernivetska': 'iso2:UA-77',
+}
 
 module.exports = {
   aggregate: 'state',
@@ -32,27 +38,16 @@ module.exports = {
       scrape ($, date, { getIso2FromName }) {
         const states = []
 
-        const getIso2inUA = (name) => {
-          if (name === 'Kyiv') {
-            return 'iso2:UA-30'
-          }
-          if (name === 'Kyivska') {
-            return 'iso2:UA-32'
-          }
-          if (name === 'Chernivetska') {
-            return 'iso2:UA-77'
-          }
-          const unSkaName = name
-            .replace('nska', '')
-            .replace('skа', '')
-            .replace('ska', '')
-            .replace('zka', '')
-          return getIso2FromName({ country, name: unSkaName })
-        }
-
         for (const state of $.ukraine) {
           states.push({
-            state: getIso2inUA(state.label.en),
+            state: getIso2FromName({
+              country, name: state.label.en
+                .replace('nska', '')
+                .replace('skа', '')
+                .replace('ska', '')
+                .replace('zka', '')
+              , isoMap
+            }),
             cases: parse.number(state.confirmed),
             deaths: parse.number(state.deaths),
             recovered: parse.number(state.recovered)


### PR DESCRIPTION
## Summary

Three patterns have emerged for coercing names into something we are able to iso2 lookup.

- Replacements ( `_` to ` `)
- Make names canonical
- Make names un-ambigious (New York as State vs City)

The idea to not just map them all directly to ISO2s is so that the mappings are as human-readable as possible (no one knows at a glance whether 'Antwerpen' is 'BE-VAN', but they can tell that             'Antwerpen' is 'Antwerp').

## Changes

- Introduce two new options to the util, so we can align these, as well as helpful assertions that show how to use this functionality.