### PR TITLE
Add test coverage for crawl 'data' property.

### DIFF
--- a/src/shared/sources/_lib/validate-source.js
+++ b/src/shared/sources/_lib/validate-source.js
@@ -76,11 +76,17 @@ function validateSource (source) {
 
       // Crawl type
       requirement(allowed.some(a => a === type), datedError(
-        `Invalid crawler type '${type}'; must be one of: page, headless, csv, tsv, pdf, json, raw`
+        `Invalid crawler.type '${type}'; must be one of: page, headless, csv, tsv, pdf, json, raw`
       ))
 
-      // Crawl data format type (for ranking I guess?)
-      requirement(is.string(data) || !data, datedError('Crawler data must be a string'))
+      // Crawl data (format) type, for ranking
+      if (data) {
+        requirement(is.string(data), datedError('Crawler data must be a string'))
+        const allowedData = [ 'table', 'list', 'paragraph' ]
+        requirement(allowedData.some(a => a === data), datedError(
+          `Invalid crawler.data '${data}'; must be one of: ${allowedData.join(', ')}`
+        ))
+      }
 
       // Crawl URL
       requirement(is.string(url) || is.function(url), datedError('Crawler url must be a string or function'))

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -62,7 +62,7 @@ test('validateSource catches problems', t => {
       {
         startDate: '2020-03-02',
         crawl: [
-          { name: 'cases', type: 'csv', url: 'https://somedata.csv' },
+          { name: 'cases', type: 'csv', data: 'trash', url: 'https://somedata.csv' },
           { name: 'cases' /* dup. name */, type: 'page', url: 'https://somedata.html' }
         ],
         scrape (data) { return { cases: 42 + data.count } }
@@ -84,7 +84,8 @@ test('validateSource catches problems', t => {
     '(missing startDate): Async scraper; scrapers should only contain synchronous logic.',
     'Country must be a properly formatted ISO key (e.g. \'iso1:US\')',
     '2020-03-02: Duplicate crawler name \'cases\'; names must be unique',
-    '2020-03-01: Invalid crawler type \'text\'; must be one of: page, headless, csv, tsv, pdf, json, raw',
+    '2020-03-02: Invalid crawler.data \'trash\'; must be one of: table, list, paragraph',
+    '2020-03-01: Invalid crawler.type \'text\'; must be one of: page, headless, csv, tsv, pdf, json, raw',
     'Scraper must contain a startDate',
     '2020-03-03: Single crawler must not have a name key',
     '(missing startDate): Single crawler must not have a name key'


### PR DESCRIPTION
Data must be list, table, or paragraph ... I think that's about it.