### PR TITLE
Migrate PL

### DIFF
--- a/src/events/scraper/run-scraper/scraper-helpers/get-iso2-from-name.js
+++ b/src/events/scraper/run-scraper/scraper-helpers/get-iso2-from-name.js
@@ -22,6 +22,7 @@ slugify.extend({ 'ō': 'o' })
  */
 module.exports = function getIso2FromName (params) {
   const { isoMap, nameToCanonical, country, name } = params
+  assert(name && name.length > 0, `name must be non-empty string, got '${name}'`)
   const countryCode = country.replace('iso1:', '')
   const iso2WithinIso1 = Object.values(iso2).filter(item => item.iso2.startsWith(countryCode))
   const nameForMatching = (nameToCanonical || {})[name] || name

--- a/src/shared/sources/pl/index.js
+++ b/src/shared/sources/pl/index.js
@@ -1,0 +1,84 @@
+const parse = require('../_lib/parse.js')
+const maintainers = require('../_lib/maintainers.js')
+
+const isoMap = require('./mapping.json')
+
+const country = "iso1:PL"
+
+module.exports = {
+    country,
+    maintainers: [ maintainers.qgolsteyn, maintainers.ciscorucinski ],
+    friendly: {
+        name: 'Ministry of Health of the Republic of Poland',
+        url: 'http://www.mz.gov.pl/'
+    },
+    scrapers: [
+        // TODO (scraper) PL: 2020-03-18 scraper
+        // {
+        //     startDate: '2020-03-18',
+        //     crawl: [
+        //         {
+        //             type: 'csv',
+        //             url: 'https://raw.githubusercontent.com/covid19-eu-zh/covid19-eu-data/master/dataset/covid-19-pl.csv'
+        //         }
+        //     ],
+        //     scrape (data, date) {
+        //         const casesByRegion = {}
+        //         const deathsByRegion = {}
+        //
+        //         for (const item of data) {
+        //             const {datetime, nuts_2} = item;
+        //             if (datetime.dateIsBeforeOrEqualTo(datetime, date) && nuts_2) {
+        //                 casesByRegion[nuts_2] = parse.number(item.cases)
+        //                 deathsByRegion[nuts_2] = parse.number(item.deaths)
+        //             }
+        //         }
+        //
+        //         const states = []
+        //         for (const region of Object.keys(casesByRegion)) {
+        //             states.push({
+        //                 state: mapping[region],
+        //                 cases: casesByRegion[region]
+        //             })
+        //         }
+        //
+        //         if (states.length > 0) states.push(transform.sumData(states))
+        //         return states
+        //     }
+        // },
+        {
+            startDate: '2020-04-13',
+            crawl: [
+                {
+                    type: 'page',
+                    url: 'https://www.gov.pl/web/koronawirus/wykaz-zarazen-koronawirusem-sars-cov-2',
+                }
+            ],
+            // eslint-disable-next-line no-unused-vars
+            scrape ($, date, { getIso2FromName }) {
+                console.log("New Scraper")
+                const $pre = $('#registerData')
+                const casesData = JSON.parse(JSON.parse($pre.text()).parsedData)
+
+                const casesByRegion = {}
+                const deathsByRegion = {}
+
+                for (const item of casesData) {
+                    casesByRegion[item['Województwo']] = parse.number(item.Liczba)
+                    deathsByRegion[item['Województwo']] = parse.number(item['Liczba zgonów'])
+                }
+
+                const data = []
+                for (const region of Object.keys(casesByRegion)) {
+                    if (region === "Cała Polska") continue
+                    data.push({
+                        state: getIso2FromName({ country, name: region, isoMap }),
+                        cases: casesByRegion[region],
+                        deaths: deathsByRegion[region]
+                    })
+                }
+                return data
+            }
+        }
+    ]
+}

--- a/src/shared/sources/pl/index.js
+++ b/src/shared/sources/pl/index.js
@@ -1,6 +1,7 @@
 const parse = require('../_lib/parse.js')
 const maintainers = require('../_lib/maintainers.js')
 const transform = require('../_lib/transform.js')
+const spacetime = require('spacetime')
 
 const isoMap = require('./mapping.json')
 
@@ -25,12 +26,12 @@ module.exports = {
             scrape (data, date) {
                 const casesByRegion = {}
                 const deathsByRegion = {}
-
                 for (const item of data) {
-                    const { datetime, nuts_2 } = item
-                if ((datetime <= date) && nuts_2) {
-                        casesByRegion[nuts_2] = parse.number(item.cases)
-                        deathsByRegion[nuts_2] = parse.number(item.deaths)
+                    const dt = spacetime(item.datetime, 'Europe/Warsaw')
+                    const nuts_2 = item.nuts_2
+                    if (dt.isBefore(date) && nuts_2) {
+                        casesByRegion[nuts_2] = parseInt(item.cases, 10)
+                        deathsByRegion[nuts_2] = parse.number(item.deaths, 10)
                     }
                 }
 

--- a/src/shared/sources/pl/index.js
+++ b/src/shared/sources/pl/index.js
@@ -80,6 +80,7 @@ module.exports = {
                         deaths: deathsByRegion[region]
                     })
                 }
+                if (data.length > 0) data.push(transform.sumData(data))
                 return data
             }
         }

--- a/src/shared/sources/pl/index.js
+++ b/src/shared/sources/pl/index.js
@@ -69,8 +69,11 @@ module.exports = {
                 }
 
                 const data = []
-                for (const region of Object.keys(casesByRegion)) {
-                    if (region === "Cała Polska") continue
+                const validRegions = Object.keys(casesByRegion).
+                    filter(r => r !== '').
+                    filter(r => r !== 'Cała Polska').
+                    filter(r => !r.match(/^http/))
+                for (const region of validRegions) {
                     data.push({
                         state: getIso2FromName({ country, name: region, isoMap }),
                         cases: casesByRegion[region],

--- a/src/shared/sources/pl/index.js
+++ b/src/shared/sources/pl/index.js
@@ -1,5 +1,6 @@
 const parse = require('../_lib/parse.js')
 const maintainers = require('../_lib/maintainers.js')
+const transform = require('../_lib/transform.js')
 
 const isoMap = require('./mapping.json')
 
@@ -13,39 +14,38 @@ module.exports = {
         url: 'http://www.mz.gov.pl/'
     },
     scrapers: [
-        // TODO (scraper) PL: 2020-03-18 scraper
-        // {
-        //     startDate: '2020-03-18',
-        //     crawl: [
-        //         {
-        //             type: 'csv',
-        //             url: 'https://raw.githubusercontent.com/covid19-eu-zh/covid19-eu-data/master/dataset/covid-19-pl.csv'
-        //         }
-        //     ],
-        //     scrape (data, date) {
-        //         const casesByRegion = {}
-        //         const deathsByRegion = {}
-        //
-        //         for (const item of data) {
-        //             const {datetime, nuts_2} = item;
-        //             if (datetime.dateIsBeforeOrEqualTo(datetime, date) && nuts_2) {
-        //                 casesByRegion[nuts_2] = parse.number(item.cases)
-        //                 deathsByRegion[nuts_2] = parse.number(item.deaths)
-        //             }
-        //         }
-        //
-        //         const states = []
-        //         for (const region of Object.keys(casesByRegion)) {
-        //             states.push({
-        //                 state: mapping[region],
-        //                 cases: casesByRegion[region]
-        //             })
-        //         }
-        //
-        //         if (states.length > 0) states.push(transform.sumData(states))
-        //         return states
-        //     }
-        // },
+        {
+            startDate: '2020-03-18',
+            crawl: [
+                {
+                    type: 'csv',
+                    url: 'https://raw.githubusercontent.com/covid19-eu-zh/covid19-eu-data/master/dataset/covid-19-pl.csv'
+                }
+            ],
+            scrape (data, date) {
+                const casesByRegion = {}
+                const deathsByRegion = {}
+
+                for (const item of data) {
+                    const { datetime, nuts_2 } = item
+                if ((datetime <= date) && nuts_2) {
+                        casesByRegion[nuts_2] = parse.number(item.cases)
+                        deathsByRegion[nuts_2] = parse.number(item.deaths)
+                    }
+                }
+
+                const states = []
+                for (const region of Object.keys(casesByRegion)) {
+                    states.push({
+                        state: isoMap[region],
+                        cases: casesByRegion[region]
+                    })
+                }
+
+                if (states.length > 0) states.push(transform.sumData(states))
+                return states
+            }
+        },
         {
             startDate: '2020-04-13',
             crawl: [

--- a/src/shared/sources/pl/mapping.json
+++ b/src/shared/sources/pl/mapping.json
@@ -1,0 +1,18 @@
+{
+  "podlaskie": "iso2:PL-20",
+  "lubuskie": "iso2:PL-08",
+  "świętokrzyskie": "iso2:PL-26",
+  "małopolskie": "iso2:PL-12",
+  "zachodniopomorskie": "iso2:PL-32",
+  "kujawsko-pomorskie": "iso2:PL-04",
+  "pomorskie": "iso2:PL-22",
+  "opolskie": "iso2:PL-16",
+  "warmińsko-mazurskie": "iso2:PL-28",
+  "wielkopolskie": "iso2:PL-30",
+  "podkarpackie": "iso2:PL-18",
+  "lubelskie": "iso2:PL-06",
+  "śląskie": "iso2:PL-24",
+  "dolnośląskie": "iso2:PL-02",
+  "łódzkie": "iso2:PL-10",
+  "mazowieckie": "iso2:PL-14"
+}


### PR DESCRIPTION
Building on https://github.com/covidatlas/li/pull/167 from @ciscorucinski .

After generating raw files from CDS and this, comparison is equal:

`node tools-migration/report-cds-vs-li.js zz-pl-out/ ../coronadatascraper/dist/ > report_PL.txt`

```
iso1:PL/iso2:PL-02/undefined
┌─────────┬──────────────┬───────┬──────┬─────┬───────┬──────┬─────┬───────┬──────┬─────┬───────┬──────┬─────┬───────┬──────┬─────┐
│ (index) │     date     │ cds_c │ li_c │ c=? │ cds_r │ li_r │ r=? │ cds_d │ li_d │ d=? │ cds_t │ li_t │ t=? │ cds_h │ li_h │ h=? │
├─────────┼──────────────┼───────┼──────┼─────┼───────┼──────┼─────┼───────┼──────┼─────┼───────┼──────┼─────┼───────┼──────┼─────┤
│    0    │ '2020-03-20' │ null  │  53  │ 'x' │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    1    │ '2020-03-21' │  58   │  58  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    2    │ '2020-03-22' │  66   │  66  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    3    │ '2020-03-23' │  79   │  79  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    4    │ '2020-03-24' │  101  │ null │ 'x' │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │

... here, li data goes to null b/c I didn't bother filling the cache for each day.  Where cache is present, they're equal.
When cache is present for the new scraper, they're equal

│   24    │ '2020-04-13' │  697  │ null │ 'x' │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   25    │ '2020-04-14' │  709  │ 709  │ ''  │ null  │ null │ ''  │  24   │  24  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   26    │ '2020-04-15' │  723  │ 723  │ ''  │ null  │ null │ ''  │  25   │  25  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   27    │ '2020-04-16' │  764  │ 764  │ ''  │ null  │ null │ ''  │  25   │  25  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   28    │ '2020-04-17' │  819  │ 819  │ ''  │ null  │ null │ ''  │  28   │  28  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   29    │ '2020-04-18' │  893  │ 893  │ ''  │ null  │ null │ ''  │  30   │  30  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   30    │ '2020-04-19' │  949  │ 949  │ ''  │ null  │ null │ ''  │  30   │  30  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │

... etc. ...

│   54    │ '2020-05-13' │ 2056  │ 2056 │ ''  │ null  │ null │ ''  │  78   │  78  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   55    │ '2020-05-14' │ 2100  │ 2100 │ ''  │ null  │ null │ ''  │  79   │  79  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   56    │ '2020-05-15' │ 2125  │ 2125 │ ''  │ null  │ null │ ''  │  82   │  82  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
└─────────┴──────────────┴───────┴──────┴─────┴───────┴──────┴─────┴───────┴──────┴─────┴───────┴──────┴─────┴───────┴──────┴─────┘


iso1:PL/undefined/undefined
┌─────────┬──────────────┬───────┬───────┬─────┬───────┬──────┬─────┬───────┬──────┬─────┬───────┬──────┬─────┬───────┬──────┬─────┐
│ (index) │     date     │ cds_c │ li_c  │ c=? │ cds_r │ li_r │ r=? │ cds_d │ li_d │ d=? │ cds_t │ li_t │ t=? │ cds_h │ li_h │ h=? │
├─────────┼──────────────┼───────┼───────┼─────┼───────┼──────┼─────┼───────┼──────┼─────┼───────┼──────┼─────┼───────┼──────┼─────┤
│    0    │ '2020-03-20' │ null  │  355  │ 'x' │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    1    │ '2020-03-21' │  425  │  425  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    2    │ '2020-03-22' │  536  │  536  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    3    │ '2020-03-23' │  633  │  633  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│    4    │ '2020-03-24' │  749  │ null  │ 'x' │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │

... same as above, numbers are the same at country level.

│   24    │ '2020-04-13' │ 6674  │ null  │ 'x' │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   25    │ '2020-04-14' │ 6934  │ 6934  │ ''  │ null  │ null │ ''  │  245  │ 245  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   26    │ '2020-04-15' │ 7202  │ 7202  │ ''  │ null  │ null │ ''  │  263  │ 263  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   27    │ '2020-04-16' │ 7582  │ 7582  │ ''  │ null  │ null │ ''  │  286  │ 286  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
│   28    │ '2020-04-17' │ 7918  │ 7918  │ ''  │ null  │ null │ ''  │  314  │ 314  │ ''  │ null  │ null │ ''  │ null  │ null │ ''  │
```