### PR TITLE
Add pagination

### DIFF
--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -54,8 +54,8 @@ module.exports = async function crawl (event) {
           return crawler(type, crawlOpts)
         }
         const bodies = await paginated(paginatedClient)
-        bodies.forEach(body => {
-          const result = { ...baseResult, data: body }
+        bodies.forEach((body, page) => {
+          const result = { ...baseResult, data: body, page }
           results.push(result)
         })
       }

--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -60,7 +60,7 @@ module.exports = async function crawl (event) {
         })
       }
     }
-    console.log(JSON.stringify(results, null, 2))
+    // console.log(JSON.stringify(results, null, 2))
 
     const names = results.map(r => r._name)
     const uniqueNames = Array.from(new Set(names))

--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -53,16 +53,19 @@ module.exports = async function crawl (event) {
           const crawlOpts = { ...crawl, url, ...options }
           return crawler(type, crawlOpts)
         }
-        const responses = await paginated(paginatedClient)
-        responses.forEach(response => {
-          const result = { ...baseResult, data: response.body }
+        const bodies = await paginated(paginatedClient)
+        bodies.forEach(body => {
+          const result = { ...baseResult, data: body }
           results.push(result)
         })
       }
     }
+    console.log(JSON.stringify(results, null, 2))
 
-    if (results.length !== scraper.crawl.length) {
-      throw Error(`Failed to crawl all requested 'get' sources`)
+    const names = results.map(r => r._name)
+    const uniqueNames = Array.from(new Set(names))
+    if (uniqueNames.length !== scraper.crawl.length) {
+      throw Error(`Failed to crawl all requested 'get' sources, only got ${uniqueNames.join()}`)
     }
 
     /**

--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -29,21 +29,24 @@ module.exports = async function crawl (event) {
     // TODO maybe want to make this Promise.all once things are stable
     for (let crawl of scraper.crawl) {
       let { type, url } = crawl
+
+      const _name = scraper.crawl.length > 1 ? crawl.name : 'default'
+      const baseResult = {
+        // Caching metadata
+        _sourceKey,
+        _name,
+        // Payload
+        type
+      }
+
       if (typeof url !== 'string') {
         const result = await url(crawler.client)
         Object.assign(crawl, result)
       }
 
       const response = await crawler(type, crawl)
-      const data = response.body
-      const result = {
-        // Caching metadata
-        _sourceKey,
-        _name: scraper.crawl.length > 1 ? crawl.name : 'default',
-        // Payload
-        data,
-        type
-      }
+
+      const result = { ...baseResult, data: response.body }
 
       results.push(result)
     }

--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -1,4 +1,5 @@
 const getSource = require('@architect/shared/sources/_lib/get-source.js')
+const assert = require('assert')
 const crawler = require('./crawler')
 const cache = require('./cache')
 
@@ -54,6 +55,7 @@ module.exports = async function crawl (event) {
           return crawler(type, crawlOpts)
         }
         const bodies = await paginated(paginatedClient)
+        assert(Array.isArray(bodies), `pagination must return an array, but got ${typeof(bodies)}`)
         bodies.forEach((body, page) => {
           const result = { ...baseResult, data: body, page }
           results.push(result)

--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -50,11 +50,8 @@ module.exports = async function crawl (event) {
         results.push(result)
       }
       if (paginated) {
-        async function paginatedClient (url, options = {}) {
-          const crawlOpts = { ...crawl, url, ...options }
-          return crawler(type, crawlOpts)
-        }
-        const bodies = await paginated(paginatedClient)
+        const pc = crawler.makePaginatedClient(type, crawl)
+        const bodies = await paginated(pc)
         assert(Array.isArray(bodies), `pagination must return an array, but got ${typeof(bodies)}`)
         bodies.forEach((body, page) => {
           const result = { ...baseResult, data: body, page }

--- a/src/events/crawler/cache/_cache-namer.js
+++ b/src/events/crawler/cache/_cache-namer.js
@@ -3,19 +3,18 @@ const hash = require('@architect/shared/cache/_hash.js')
 const convert = require('@architect/shared/cache/_convert-timestamp.js')
 const { extensions } = require('@architect/shared/sources/_lib/crawl-types.js')
 
-module.exports = function cacheNamer (params) {
+module.exports = function cacheNamer (datetimeISOString, params) {
   const { _sourceKey, _name, data, type, page } = params
 
   // Filepath
-  const now = new Date().toISOString()
-  const date = now.substr(0, 10)
+  const date = datetimeISOString.substr(0, 10)
   const filepath = join(_sourceKey, date)
 
   // Filename
   const pageIndicator = (page !== undefined) ? `-${page}` : ''
   const contents = hash(data, 5)
   const ext = extensions[type]
-  const time = convert.Z8601ToFilename(now)
+  const time = convert.Z8601ToFilename(datetimeISOString)
 
   const filename = `${time}-${_name}${pageIndicator}-${contents}.${ext}`
 

--- a/src/events/crawler/cache/_cache-namer.js
+++ b/src/events/crawler/cache/_cache-namer.js
@@ -4,7 +4,7 @@ const convert = require('@architect/shared/cache/_convert-timestamp.js')
 const { extensions } = require('@architect/shared/sources/_lib/crawl-types.js')
 
 module.exports = function cacheNamer (params) {
-  const { _sourceKey, _name, data, type } = params
+  const { _sourceKey, _name, data, type, page } = params
 
   // Filepath
   const now = new Date().toISOString()
@@ -12,10 +12,12 @@ module.exports = function cacheNamer (params) {
   const filepath = join(_sourceKey, date)
 
   // Filename
+  const pageIndicator = (page !== undefined) ? `-${page}` : ''
   const contents = hash(data, 5)
   const ext = extensions[type]
   const time = convert.Z8601ToFilename(now)
-  const filename = `${time}-${_name}-${contents}.${ext}`
+
+  const filename = `${time}-${_name}${pageIndicator}-${contents}.${ext}`
 
   return { filepath, filename }
 }

--- a/src/events/crawler/cache/index.js
+++ b/src/events/crawler/cache/index.js
@@ -11,9 +11,10 @@ module.exports = async function saveToCache (results) {
   const local = process.env.NODE_ENV === 'testing'
   const write = local ? writeLocal : writeS3
 
+  const now = new Date().toISOString()
   for (const result of results) {
     const { data } = result
-    const { filepath, filename } = cacheNamer(result)
+    const { filepath, filename } = cacheNamer(now, result)
     await write(data, filepath, filename)
   }
 }

--- a/src/events/crawler/crawler/index.js
+++ b/src/events/crawler/crawler/index.js
@@ -51,5 +51,15 @@ async function client (params) {
   return response
 }
 
+// Create an async client to pass to crawl.paginated functions
+function makePaginatedClient (type, sourceCrawl) {
+  return async function paginatedClient (url, options = {}) {
+    const crawlOpts = { ...sourceCrawl, url, ...options }
+    return crawl(type, crawlOpts)
+  }
+}
+
 crawl.client = client
+crawl.makePaginatedClient = makePaginatedClient
+
 module.exports = crawl

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -38,6 +38,11 @@ async function load (params, useS3) {
       tz
     })
 
+    // Remove duplicate filenames.
+    const fileset = new Set(files)
+    files = Array.from(fileset)
+
+    // TODO: move parts of this into separate modules and add tests.
     if (!timeseries && files.length) {
       /**
        * If date is earlier than we have cached, bail

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -90,15 +90,12 @@ async function load (params, useS3) {
       // We may have multiple files for this day, choose the last one
       const file = matches[matches.length - 1]
 
-      let getContent
-      if (!paginated) {
-        getContent = [ loader.getFileContents({ _sourceKey, keys, file }) ]
-      }
-      else {
-        getContent = parseCacheFilename.matchPaginatedSet(file, files).
-          map(file => loader.getFileContents({ _sourceKey, keys, file }))
-      }
-      crawl.pages = await Promise.all(getContent)
+      let fileset = [ file ]
+      if (paginated)
+        fileset = parseCacheFilename.matchPaginatedSet(file, files)
+
+      const allContent = fileset.map(file => loader.getFileContents({ _sourceKey, keys, file }))
+      crawl.pages = await Promise.all(allContent)
       cache.push(crawl)
     }
     if (cache !== 'miss') {

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -123,34 +123,3 @@ async function loadCache (params) {
 }
 
 module.exports = loadCache
-
-// TODO (refactor) Change API to take the loader, and add tests.
-// Passing in the loader object rather than a boolean should clarify flow.
-// Can also standardize on throwing instead of returning false, e.g:
-
-/*
-
-async function load(params, loader) { ... }
-
-async function loadCache(params) {
-  if (isLocal) {
-    try {
-      let result = await load(params, localLoader)
-      return result
-    }
-    catch {
-      ... cache miss
-    }
-  }
-
-  // S3 load
-  try {
-    let result = await load(params, S3Loader)
-    return result
-  }
-  catch {
-    ... failure
-  }
-}
-
-*/

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -43,7 +43,6 @@ async function load (params, useS3) {
     const fileset = new Set(files)
     files = Array.from(fileset)
 
-    // TODO: move parts of this into separate modules and add tests.
     if (!timeseries && files.length) {
       /**
        * If date is earlier than we have cached, bail
@@ -124,3 +123,34 @@ async function loadCache (params) {
 }
 
 module.exports = loadCache
+
+// TODO (refactor) Change API to take the loader, and add tests.
+// Passing in the loader object rather than a boolean should clarify flow.
+// Can also standardize on throwing instead of returning false, e.g:
+
+/*
+
+async function load(params, loader) { ... }
+
+async function loadCache(params) {
+  if (isLocal) {
+    try {
+      let result = await load(params, localLoader)
+      return result
+    }
+    catch {
+      ... cache miss
+    }
+  }
+
+  // S3 load
+  try {
+    let result = await load(params, S3Loader)
+    return result
+  }
+  catch {
+    ... failure
+  }
+}
+
+*/

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -76,7 +76,7 @@ async function load (params, useS3) {
 
     const parsedFilenames = files.reduce((arr, f) => {
       const { datetime, name, page } = parseCacheFilename(f)
-      arr.push( { filename: f, datetime, name, page } )
+      arr.push( { filename: f, datetime, name, page: (page || 0) } )
       return arr
     }, [])
 
@@ -115,6 +115,7 @@ async function load (params, useS3) {
             (f.page !== undefined)
         ).sort((a, b) => a.page - b.page).
               map(f => f.filename)
+        console.log(`all pages in set = ${pages.join()}`)
         return pages
       }
 

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -75,7 +75,7 @@ async function load (params, useS3) {
     }
 
     const parsedFilenames = files.reduce((arr, f) => {
-      const { datetime, name, page } = parseCacheFilename(f)
+      const { datetime, name, page } = parseCacheFilename.parse(f)
       arr.push( { filename: f, datetime, name, page: (page || 0) } )
       return arr
     }, [])
@@ -86,13 +86,7 @@ async function load (params, useS3) {
       // Disambiguate and match them so we are getting back the correct data sources
       const { name='default', paginated } = crawl
 
-      function matchNameAndPage (file) {
-        const p = parsedFilenames.find(e => e.filename === file)
-        assert(p, `Missing filename ${file} in parsed`)
-        return (p.name === name) && ((p.page || 0) === 0)
-      }
-
-      const matches = files.filter(matchNameAndPage)
+      const matches = parseCacheFilename.matchName(name, files)
 
       // Fall back to S3 cache
       if (!matches.length) {

--- a/src/events/scraper/parse-cache/index.js
+++ b/src/events/scraper/parse-cache/index.js
@@ -19,19 +19,17 @@ module.exports = async function parseCache (cache) {
 
   const parsed = []
   for (const hit of cache) {
-    let { content, options } = hit
-    // Convert non-binaries out of the buffer
-    let result
-    if (hit.type !== 'pdf') {
-      content = content.toString()
-      result = parse[hit.type]({ content, options })
-    }
-    else {
-      result = await parse[hit.type]({ content })
-    }
+    let { pages, options } = hit
+
+    const parsePromises = pages.
+          map(p => (hit.type !== 'pdf') ? p.toString() : p).
+          map(content => parse[hit.type]({ content, options }))
+    const results = await Promise.all(parsePromises)
+    const result = hit.paginated ? results : results[ 0 ]
+
     const name = hit.name || 'default'
     parsed.push({ [name]: result })
   }
-  return parsed
 
+  return parsed
 }

--- a/src/shared/sources/_lib/arcgis.js
+++ b/src/shared/sources/_lib/arcgis.js
@@ -1,3 +1,5 @@
+const assert = require('assert')
+
 /**
  * Open the arcgis iframe and look in the Network/XHR tab for requests with Name of "0".
  *
@@ -18,6 +20,79 @@ async function urlFromOrgId (client, serverNumber, orgId, layerName) {
   return ret
 }
 
+
+/**
+ * Retrieves data from an ArcGIS REST API. By default, it will
+ * retrieve all items at the provided linked with geometry turned off.
+ * You can control pagination size through the `featuresToFetch`
+ * parameter in `options`, but this should not be necessary - by
+ * default, this will make the largest request allowed by the source.
+ *
+ * @param {string} featureLayerURL URL of the resource, up to and
+ * including the feature layer number and `query`, e.g.
+ * https://services5.arcgis.com/fsYDFeRKu1hELJJs/arcgis/rest/
+ *    services/FOHM_Covid_19_FME_1/FeatureServer/1/query
+ *
+ * @param {object} options customizable options: - featuresToFetch:
+ * number of features we want to receive for each request. A smaller
+ * number means more request to grab the complete dataset, a larger
+ * number may result in a partial dataset if we request more than `Max
+ * Record Count`. Defaults to 500.
+ *
+ * - additionalParams: additional parameters for this request.
+ * Defaults to `where=0%3D0&outFields=*&returnGeometry=false`.
+ */
+async function crawlPaginated (client, featureLayerURL, options = {}) {
+  const { featuresToFetch, additionalParams } = {
+    featuresToFetch: undefined,
+    additionalParams: 'where=0%3D0&outFields=*&returnGeometry=false',
+    ...options
+  }
+
+  if (featureLayerURL.search(/\/query$/) === -1) {
+    throw new Error(`Invalid URL: "${featureLayerURL}" does not end with "query"`)
+  }
+
+  let url = `${featureLayerURL.replace(/\?.*$/, '')}?f=json${additionalParams ? `&${additionalParams}` : ''}`
+
+  // Won't get anything back without these.  Note also that if any
+  // query parameters are in there twice, you get a 400 back.
+  if (url.search('where=') === -1)
+    url += '&where=0%3D0'
+  if (url.search('outFields=') === -1)
+    url += '&outFields=*'
+  if (featuresToFetch)
+    url += `&resultRecordCount=${featuresToFetch}`
+
+  const result = []
+
+  let exceededTransferLimit = true
+  let n = 0
+  while (exceededTransferLimit) {
+    console.log(`... getting offset ${n}`)
+    let { body } = await client( { url: `${url}&resultOffset=${n}` } )
+    result.push(body)
+    let j = JSON.parse(body)
+    exceededTransferLimit = j.exceededTransferLimit
+    n += j.features.length
+  }
+
+  console.log(`returning ${result.length} pages, type = ${typeof(result)}`)
+  return result
+}
+
+
+/** Load the features from a crawlPaginated set of bodies. */
+function loadPaginatedFeatures (bodies) {
+  assert(Array.isArray(bodies), 'arcgis should have loaded an array')
+  console.log(`Loading ${bodies.length} pages of data`)
+  assert(bodies.some(b => b.features.length === 0) === false, 'All bodies have features')
+  return bodies.map(b => b.features).flat()
+}
+
+
 module.exports = {
-  urlFromOrgId
+  urlFromOrgId,
+  crawlPaginated,
+  loadPaginatedFeatures
 }

--- a/src/shared/sources/_lib/validate-source.js
+++ b/src/shared/sources/_lib/validate-source.js
@@ -72,7 +72,7 @@ function validateSource (source) {
     // Ok, now let's go into the crawler(s)
     let crawlerNames = {}
     for (const crawler of crawl) {
-      const { type, data, url, timeout } = crawler
+      const { type, data, url, paginated, timeout } = crawler
 
       // Crawl type
       requirement(allowed.some(a => a === type), datedError(
@@ -88,8 +88,19 @@ function validateSource (source) {
         ))
       }
 
+      requirement(url || paginated, datedError('Require url or paginated'))
+      requirement(([ url, paginated ].filter(s => s).length === 1), datedError('Require url or paginated, not both'))
+
       // Crawl URL
-      requirement(is.string(url) || is.function(url), datedError('Crawler url must be a string or function'))
+      if (url) {
+        requirement(is.string(url) || is.function(url), datedError('Crawler url must be a string or function'))
+      }
+      if (paginated) {
+        requirement(
+          is.function(paginated) && paginated.constructor.name === 'AsyncFunction',
+          datedError('Crawler paginated must be an async function')
+        )
+      }
 
       // Crawl name keys
       if (crawl.length === 1) {

--- a/src/shared/sources/_lib/validate-source.js
+++ b/src/shared/sources/_lib/validate-source.js
@@ -88,8 +88,8 @@ function validateSource (source) {
         ))
       }
 
-      requirement(url || paginated, datedError('Require url or paginated'))
-      requirement(([ url, paginated ].filter(s => s).length === 1), datedError('Require url or paginated, not both'))
+      requirement(url || paginated, datedError('Crawler must have either url or paginated'))
+      requirement(!(url && paginated), datedError('Crawler must have either url or paginated, but not both'))
 
       // Crawl URL
       if (url) {

--- a/src/shared/sources/jp/index.js
+++ b/src/shared/sources/jp/index.js
@@ -21,40 +21,6 @@ module.exports = {
       crawl: [
         {
           type: 'json',
-          url:
-            'https://services8.arcgis.com/JdxivnCyd1rvJTrY/arcgis/rest/services/v2_covid19_list_csv/FeatureServer/0/query?where=0%3D0&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=*&returnGeometry=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pjson'
-        }
-      ],
-      scrape ($, date, { getIso2FromName, groupBy }) {
-        assert($.features.length > 0, 'features are unreasonable')
-        const attributes = $.features
-          .map(({ attributes }) => attributes)
-          .filter((item) => item.Date && datetime.dateIsBeforeOrEqualTo(new Date(item.Date), new Date(date)))
-
-        assert(attributes.length > 0, 'data fetch failed, no attributes')
-
-        const groupedByState = groupBy(attributes, attribute => attribute.Prefecture)
-
-        const states = []
-        for (const [ stateName, stateAttributes ] of Object.entries(groupedByState)) {
-          states.push({
-            state: getIso2FromName({ country, name: stateName }),
-            cases: stateAttributes.length
-          })
-        }
-
-        const summedData = transform.sumData(states)
-        states.push(summedData)
-
-        console.table(states)
-        return states
-      }
-    },
-    {
-      startDate: '2020-05-27',
-      crawl: [
-        {
-          type: 'json',
           paginated: async client => {
             const url = 'https://services8.arcgis.com/JdxivnCyd1rvJTrY/arcgis/rest/services/v2_covid19_list_csv/FeatureServer/0/query'
             return arcgis.crawlPaginated(client, url)

--- a/src/shared/sources/jp/index.js
+++ b/src/shared/sources/jp/index.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const maintainers = require('../_lib/maintainers.js')
 const transform = require('../_lib/transform.js')
 const datetime = require('../../datetime/index.js')
+const arcgis = require('../_lib/arcgis.js')
 
 const country = 'iso1:JP'
 module.exports = {
@@ -45,6 +46,41 @@ module.exports = {
         const summedData = transform.sumData(states)
         states.push(summedData)
 
+        console.table(states)
+        return states
+      }
+    },
+    {
+      startDate: '2020-05-27',
+      crawl: [
+        {
+          type: 'json',
+          paginated: async client => {
+            const url = 'https://services8.arcgis.com/JdxivnCyd1rvJTrY/arcgis/rest/services/v2_covid19_list_csv/FeatureServer/0/query'
+            return arcgis.crawlPaginated(client, url)
+          }
+        }
+      ],
+      scrape (pages, date, { getIso2FromName, groupBy }) {
+        let attributes = arcgis.loadPaginatedFeatures(pages).
+            map(f => f.attributes).
+            filter(i => i.Date).
+            filter(i => datetime.dateIsBeforeOrEqualTo(new Date(i.Date), date))
+        assert(attributes.length > 0, 'data fetch failed, no attributes')
+
+        const groupedByState = groupBy(attributes, attribute => attribute.Prefecture)
+        const states = []
+        for (const [ stateName, stateAttributes ] of Object.entries(groupedByState)) {
+          states.push({
+            state: getIso2FromName({ country, name: stateName }),
+            cases: stateAttributes.length
+          })
+        }
+
+        const summedData = transform.sumData(states)
+        states.push(summedData)
+
+        // console.table(states)
         return states
       }
     }

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -24,15 +24,21 @@ function parse (filename) {
 }
 
 
-/** Helper: parse a bunch of filenames. */
+/** Helper: parse a bunch of filenames, ignoring any bad files. */
 function parseFilenames (files) {
   return files.reduce((arr, f) => {
-    const { datetime, name, page } = parse(f)
-    arr.push( { filename: f, datetime, name, page: (page || 0) } )
+    try {
+      const { datetime, name, page } = parse(f)
+      arr.push( { filename: f, datetime, name, page: (page || 0) } )
+    } catch (err) {
+      /* ignore */
+    }
     return arr
   }, [])
 }
 
+/** Get all files in files that match the given name; for paginated
+ * sets, only return the first one. */
 function matchName (name, files) {
   const parsed = parseFilenames(files)
   const ret = parsed.filter(p => (p.name === name) && ((p.page || 0) === 0))

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -24,6 +24,22 @@ function parse (filename) {
 }
 
 
+/** Helper: parse a bunch of filenames. */
+function parseFilenames (files) {
+  return files.reduce((arr, f) => {
+    const { datetime, name, page } = parse(f)
+    arr.push( { filename: f, datetime, name, page: (page || 0) } )
+    return arr
+  }, [])
+}
+
+function matchName (name, files) {
+  const parsed = parseFilenames(files)
+  const ret = parsed.filter(p => (p.name === name) && ((p.page || 0) === 0))
+  return ret.map(p => p.filename)
+}
+
 module.exports = {
-  parse
+  parse,
+  matchName
 }

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -1,3 +1,5 @@
+const assert = require('assert')
+
 /**
  * The cache filename has several significant parse which are referred
  * to during cache load, prior to scraping.
@@ -45,7 +47,25 @@ function matchName (name, files) {
   return ret.map(p => p.filename)
 }
 
+/** Get all paginated pages that have the same datetime and name. */
+function matchPaginatedSet (firstPage, files) {
+  const parsed = parseFilenames(files)
+  const p = parsed.find(e => e.filename === firstPage)
+  assert(p, `Missing filename ${firstPage} in parsed`)
+  const pages = parsed.
+        filter(f =>
+               (f.datetime === p.datetime) &&
+               (f.name === p.name) &&
+               (f.page !== undefined)
+              ).sort((a, b) => a.page - b.page).
+        map(f => f.filename)
+  console.log(`all pages in set = ${pages.join()}`)
+  return pages
+}
+
+
 module.exports = {
   parse,
-  matchName
+  matchName,
+  matchPaginatedSet
 }

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -2,7 +2,7 @@
  * The cache filename has several significant parse which are referred
  * to during cache load, prior to scraping.
  */
-module.exports = function parse (filename) {
+function parse (filename) {
   const re = /^(\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz])-([a-z]+)(-\d+)?-([a-h0-9]{5})\.([a-z]+)\..*$/
 
   if (!re.test(filename)) {
@@ -21,4 +21,9 @@ module.exports = function parse (filename) {
     parsed.page = parseInt(m[3].replace('-', ''), 10)
 
   return parsed
+}
+
+
+module.exports = {
+  parse
 }

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -1,0 +1,24 @@
+/**
+ * The cache filename has several significant parse which are referred
+ * to during cache load, prior to scraping.
+ */
+module.exports = function parse (filename) {
+  const re = /^(\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz])-([a-z]+)(-\d+)?-([a-h0-9]{5})\.([a-z]+)\..*$/
+
+  if (!re.test(filename)) {
+    throw new Error(`Bad cache filename: ${filename}`)
+  }
+  const m = filename.match(re)
+
+  const parsed = {
+    datetime: m[1],
+    name: m[2],
+    sha: m[4],
+    extension: m[5]
+  }
+
+  if (m[3])
+    parsed.page = parseInt(m[3].replace('-', ''), 10)
+
+  return parsed
+}

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -5,7 +5,7 @@ const assert = require('assert')
  * to during cache load, prior to scraping.
  */
 function parse (filename) {
-  const re = /^(\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz])-([a-z]+)(-\d+)?-([a-h0-9]{5})\.([a-z]+)\..*$/
+  const re = /^(\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz])-([a-z]+)(-\d+)?-([a-h0-9]{5})\.([a-z]+)(\..*)?$/
 
   if (!re.test(filename)) {
     throw new Error(`Bad cache filename: ${filename}`)

--- a/src/shared/utils/parse-cache-filename.js
+++ b/src/shared/utils/parse-cache-filename.js
@@ -5,7 +5,7 @@ const assert = require('assert')
  * to during cache load, prior to scraping.
  */
 function parse (filename) {
-  const re = /^(\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz])-([a-z]+)(-\d+)?-([a-h0-9]{5})\.([a-z]+)(\..*)?$/
+  const re = /^(\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}z)-([a-z]+)(-\d+)?-([a-h0-9]{5})\.([a-z]+)(\..*)?$/
 
   if (!re.test(filename)) {
     throw new Error(`Bad cache filename: ${filename}`)

--- a/src/shared/utils/validate-cache-filename.js
+++ b/src/shared/utils/validate-cache-filename.js
@@ -1,27 +1,13 @@
 const { extensions } = require('../sources/_lib/crawl-types.js')
+const { parse } = require('./parse-cache-filename.js')
 
-/**
- * It shouldn't really be feasible that we'd
- * be passed a bad cache filename because the filenames we pass to S3 should be solid (and are tested).
- * That said, during the cache migration from CDS → Li
- * there was plenty of potential for breakage,
- * so this exists (for now) to help keep things tight.
- */
 module.exports = function validateCacheFilename (filename) {
-  const check = /^\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz]-[a-z]+(-\d+)?-[a-h0-9]{5}\..*$/
-
-  // Check general shape
-  if (!check.test(filename)) {
-    throw new Error(`Bad cache filename: ${filename}`)
-  }
+  // If the name can't be parsed, it's not valid.
+  const p = parse(filename)
 
   // Check extensions
   const exts = Object.values(extensions)
-  const parts = filename.split('/')
-  // If there are folders, skip to the filename
-  const fileparts = parts[parts.length - 1].split('-')
-  const ext = fileparts.splice(-1)[0].split('.')[1]
-  if (!exts.some(a => a === ext)) {
+  if (!exts.some(a => a === p.extension)) {
     throw new Error(`Bad cache extension: ${filename}`)
   }
 }

--- a/src/shared/utils/validate-cache-filename.js
+++ b/src/shared/utils/validate-cache-filename.js
@@ -8,7 +8,7 @@ const { extensions } = require('../sources/_lib/crawl-types.js')
  * so this exists (for now) to help keep things tight.
  */
 module.exports = function validateCacheFilename (filename) {
-  const check = /^\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz]-[a-z]+-[a-h0-9]{5}\..*$/
+  const check = /^\d{4}-\d{2}-\d{2}t\d{2}_\d{2}_\d{2}\.\d{3}[Zz]-[a-z]+(-\d+)?-[a-h0-9]{5}\..*$/
 
   // Check general shape
   if (!check.test(filename)) {
@@ -20,7 +20,7 @@ module.exports = function validateCacheFilename (filename) {
   const parts = filename.split('/')
   // If there are folders, skip to the filename
   const fileparts = parts[parts.length - 1].split('-')
-  const ext = fileparts[4].split('.')[1]
+  const ext = fileparts.splice(-1)[0].split('.')[1]
   if (!exts.some(a => a === ext)) {
     throw new Error(`Bad cache extension: ${filename}`)
   }

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -4,7 +4,7 @@ const utils = require('../utils.js')
 const test = require('tape')
 const testCache = require('../../_lib/testcache.js')
 
-test('crawl saves paginated results to cache as separate files', async t => {
+test.only('crawl saves paginated results to cache as separate files', async t => {
   await utils.setup()
 
   const page1 = {
@@ -20,7 +20,14 @@ test('crawl saves paginated results to cache as separate files', async t => {
   utils.writeFakeSourceContent('paginated-json/page2.json', page2)
 
   t.equal(0, testCache.allFiles().length, 'No files in cache.')
-  await utils.crawl('fake')
+  try {
+    await utils.crawl('paginated-json')
+    t.pass('crawl succeeded')
+  }
+  catch (err) {
+    t.fail(err)
+  }
+
   t.equal(2, testCache.allFiles().length, 'have both files after crawl.')
 
   await utils.teardown()

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -1,0 +1,32 @@
+process.env.NODE_ENV = 'testing'
+
+const utils = require('../utils.js')
+const test = require('tape')
+const testCache = require('../../_lib/testcache.js')
+
+test('crawl saves paginated results to cache as separate files', async t => {
+  await utils.setup()
+
+  const page1 = {
+    date: 'Jan 1',
+    cases: 1,
+    nextUrl: 'http://localhost:5555/tests/fake-source-urls/paginated-json/page2.json'
+  }
+  const page2 = {
+    date: 'Jan 2',
+    cases: 2
+  }
+  utils.writeFakeSourceContent('paginated-json/page1.json', page1)
+  utils.writeFakeSourceContent('paginated-json/page2.json', page2)
+
+  t.equal(0, testCache.allFiles().length, 'No files in cache.')
+  await utils.crawl('fake')
+  t.equal(2, testCache.allFiles().length, 'have both files after crawl.')
+
+  await utils.teardown()
+  t.end()
+})
+
+// TODO tests
+// Files are named correctly
+// missing page = nothing is saved

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -10,7 +10,7 @@ const firstPage = {
     { date: 'Jan 1', cases: 1 },
     { date: 'Jan 2', cases: 2 }
   ],
-  nextUrl: 'http://localhost:5555/tests/fake-source-urls/paginated-json/page2.json'
+  nextUrl: 'page2.json'
 }
 
 const lastPage = {

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -4,7 +4,7 @@ const utils = require('../utils.js')
 const test = require('tape')
 const testCache = require('../../_lib/testcache.js')
 
-test.only('crawl saves paginated results to cache as separate files', async t => {
+test('crawl saves paginated results to cache as separate files', async t => {
   await utils.setup()
 
   const page1 = {

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -4,20 +4,25 @@ const utils = require('../utils.js')
 const test = require('tape')
 const testCache = require('../../_lib/testcache.js')
 
-test('crawl saves paginated results to cache as separate files', async t => {
+const firstPage = {
+  records: [
+    { date: 'Jan 1', cases: 1 },
+    { date: 'Jan 2', cases: 2 }
+  ],
+  nextUrl: 'http://localhost:5555/tests/fake-source-urls/paginated-json/page2.json'
+}
+
+const lastPage = {
+  records: [
+    { date: 'Jan 3', cases: 3 }
+  ]
+}
+
+test.only('crawl saves paginated results to cache as separate files', async t => {
   await utils.setup()
 
-  const page1 = {
-    date: 'Jan 1',
-    cases: 1,
-    nextUrl: 'http://localhost:5555/tests/fake-source-urls/paginated-json/page2.json'
-  }
-  const page2 = {
-    date: 'Jan 2',
-    cases: 2
-  }
-  utils.writeFakeSourceContent('paginated-json/page1.json', page1)
-  utils.writeFakeSourceContent('paginated-json/page2.json', page2)
+  utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
+  utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
 
   t.equal(0, testCache.allFiles().length, 'No files in cache.')
   try {

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -62,7 +62,7 @@ test('pagination saves nothing if file is missing', async t => {
   t.end()
 })
 
-test('paginated files are named correctly', async t => {
+test.only('paginated files are named correctly', async t => {
   await utils.setup()
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
@@ -78,12 +78,12 @@ test('paginated files are named correctly', async t => {
   }
 
   const cachedFiles = testCache.allFiles()
-  function haveMatchingCacheFile (pattern) {
+  t.haveMatchingCacheFile = pattern => {
     const match = cachedFiles.find(f => f.match(pattern))
     t.ok(match, `expected match for ${pattern} in ${cachedFiles.join()}`)
   }
-  haveMatchingCacheFile(/default-0-/)
-  haveMatchingCacheFile(/default-1-/)
+  t.haveMatchingCacheFile(/default-0-/)
+  t.haveMatchingCacheFile(/default-1-/)
 
   await utils.teardown()
   t.end()

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -18,12 +18,7 @@ const lastPage = {
   ]
 }
 
-test('crawl saves paginated results to cache as separate files', async t => {
-  await utils.setup()
-
-  utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
-  utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
-
+async function doCrawl (t) {
   t.equal(0, testCache.allFiles().length, 'No files in cache.')
   try {
     await utils.crawl('paginated-json')
@@ -32,8 +27,16 @@ test('crawl saves paginated results to cache as separate files', async t => {
   catch (err) {
     t.fail(err)
   }
+}
 
-  t.equal(2, testCache.allFiles().length, 'have both files after crawl.')
+test('crawl saves paginated results to cache as separate files', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
+  utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
+  await doCrawl(t)
+  t.equal(3, testCache.allFiles().length, 'all files after crawl.')
 
   await utils.teardown()
   t.end()
@@ -45,7 +48,7 @@ test('pagination saves nothing if file is missing', async t => {
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
   // Page 1 refers to missing page 2
-  // utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
 
   t.equal(0, testCache.allFiles().length, 'No files in cache.')
   try {
@@ -67,23 +70,35 @@ test('paginated files are named correctly', async t => {
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
   utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
-
-  t.equal(0, testCache.allFiles().length, 'No files in cache.')
-  try {
-    await utils.crawl('paginated-json')
-    t.pass('crawl succeeded')
-  }
-  catch (err) {
-    t.fail(err)
-  }
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
+  await doCrawl(t)
 
   const cachedFiles = testCache.allFiles()
   t.haveMatchingCacheFile = pattern => {
     const match = cachedFiles.find(f => f.match(pattern))
     t.ok(match, `expected match for ${pattern} in ${cachedFiles.join()}`)
   }
-  t.haveMatchingCacheFile(/default-0-/)
-  t.haveMatchingCacheFile(/default-1-/)
+  t.haveMatchingCacheFile(/cases-0-/)
+  t.haveMatchingCacheFile(/cases-1-/)
+  t.haveMatchingCacheFile(/deaths-.{5}.json/)
+
+  await utils.teardown()
+  t.end()
+})
+
+test('single paginated file still has index', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('paginated-json/page1.json', lastPage)
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
+  await doCrawl(t)
+
+  const cachedFiles = testCache.allFiles()
+  t.haveMatchingCacheFile = pattern => {
+    const match = cachedFiles.find(f => f.match(pattern))
+    t.ok(match, `expected match for ${pattern} in ${cachedFiles.join()}`)
+  }
+  t.haveMatchingCacheFile(/cases-0-/)
 
   await utils.teardown()
   t.end()

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -90,7 +90,7 @@ test('paginated files are named correctly', async t => {
 /** The paginated set of files all get the same datetime stamp at the
  * start of the filename.  This _vastly_ simplifies fetching the files
  * from the cache during scrape. */
-test.only('paginated files in one crawl are all given the same datetime', async t => {
+test('paginated files in one crawl are all given the same datetime', async t => {
   await utils.setup()
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)

--- a/tests/integration/events/crawler/paginated-json-test.js
+++ b/tests/integration/events/crawler/paginated-json-test.js
@@ -62,7 +62,7 @@ test('pagination saves nothing if file is missing', async t => {
   t.end()
 })
 
-test.only('paginated files are named correctly', async t => {
+test('paginated files are named correctly', async t => {
   await utils.setup()
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)

--- a/tests/integration/events/scraper/multiple-urls-test.js
+++ b/tests/integration/events/scraper/multiple-urls-test.js
@@ -15,16 +15,7 @@ test('scrape of multiple files', async t => {
   t.equal(2, testCache.allFiles().length, '2 files saved after crawl.')
 
   const fullResult = await utils.scrape('multiple-urls')
-  const actual = fullResult[0].data
-  t.ok(actual, 'Have data')
-  t.equal(1, actual.length, '1 record in returned data')
-
-  const expected = { cases: 111, deaths: 222 }
-  const prunedActual = Object.keys(expected).reduce((hsh, key) => {
-    hsh[key] = actual[0][key]
-    return hsh
-  }, {})
-  t.deepEqual(expected, prunedActual, 'exact key matches')
+  utils.validateResults(t, fullResult, [ { cases: 111, deaths: 222 } ])
 
   await utils.teardown()
   t.end()

--- a/tests/integration/events/scraper/multiple-urls-test.js
+++ b/tests/integration/events/scraper/multiple-urls-test.js
@@ -1,6 +1,8 @@
 process.env.NODE_ENV = 'testing'
 
 const test = require('tape')
+const fs = require('fs')
+const path = require('path')
 const utils = require('../utils.js')
 const testCache = require('../../_lib/testcache.js')
 
@@ -16,6 +18,30 @@ test('scrape of multiple files', async t => {
 
   const fullResult = await utils.scrape('multiple-urls')
   utils.validateResults(t, fullResult, [ { cases: 111, deaths: 222 } ])
+
+  await utils.teardown()
+  t.end()
+})
+
+test('scrape fails if files missing', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('multiple-urls/cases.json', { count: 111 })
+  utils.writeFakeSourceContent('multiple-urls/deaths.json', { count: 222 })
+  t.equal(0, testCache.allFiles().length, 'No files in cache.')
+  await utils.crawl('multiple-urls')
+  t.equal(2, testCache.allFiles().length, '2 files saved after crawl.')
+
+  const f = testCache.allFiles()[0]
+  fs.unlinkSync(path.join(testCache.testingCache, f))
+
+  try {
+    await utils.scrape('multiple-urls')
+    t.fail('should have failed')
+  }
+  catch (err) {
+    t.match(err.message, /Could not load cache/)
+  }
 
   await utils.teardown()
   t.end()

--- a/tests/integration/events/scraper/multiple-urls-test.js
+++ b/tests/integration/events/scraper/multiple-urls-test.js
@@ -46,3 +46,28 @@ test('scrape fails if files missing', async t => {
   await utils.teardown()
   t.end()
 })
+
+test('scrape fails if cache files are corrupted', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('multiple-urls/cases.json', { count: 111 })
+  utils.writeFakeSourceContent('multiple-urls/deaths.json', { count: 222 })
+  t.equal(0, testCache.allFiles().length, 'No files in cache.')
+  await utils.crawl('multiple-urls')
+  t.equal(2, testCache.allFiles().length, '2 files saved after crawl.')
+
+  const f = path.join(testCache.testingCache, testCache.allFiles()[0])
+  fs.unlinkSync(f)
+  fs.writeFileSync(f, 'This is not json and it should fail parsing.')
+
+  try {
+    await utils.scrape('multiple-urls')
+    t.fail('should have failed')
+  }
+  catch (err) {
+    t.pass('failed with error: ' + err)
+  }
+
+  await utils.teardown()
+  t.end()
+})

--- a/tests/integration/events/scraper/paginated-json-test.js
+++ b/tests/integration/events/scraper/paginated-json-test.js
@@ -28,7 +28,7 @@ async function doCrawl (t) {
   }
 }
 
-test('scrape gets all pages of data', async t => {
+test.only('scrape gets all pages of data', async t => {
   await utils.setup()
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
@@ -44,6 +44,7 @@ test('scrape gets all pages of data', async t => {
   }
   catch (err) {
     t.fail(err)
+    t.fail(err.stack)
   }
 
   const expected = [

--- a/tests/integration/events/scraper/paginated-json-test.js
+++ b/tests/integration/events/scraper/paginated-json-test.js
@@ -1,0 +1,64 @@
+process.env.NODE_ENV = 'testing'
+
+const utils = require('../utils.js')
+const test = require('tape')
+const testCache = require('../../_lib/testcache.js')
+
+const firstPage = {
+  records: [
+    { date: 'Jan 1', cases: 1 },
+    { date: 'Jan 2', cases: 2 }
+  ],
+  nextUrl: 'http://localhost:5555/tests/fake-source-urls/paginated-json/page2.json'
+}
+
+const lastPage = {
+  records: [
+    { date: 'Jan 3', cases: 3 }
+  ]
+}
+
+async function doCrawl (t) {
+  try {
+    await utils.crawl('paginated-json')
+    t.pass('crawl succeeded')
+  }
+  catch (err) {
+    t.fail(err)
+  }
+}
+
+test('scrape gets all pages of data', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
+  utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
+  await doCrawl(t)
+  t.equal(3, testCache.allFiles().length, 'all files after crawl.')
+
+  let fullResult
+  try {
+    fullResult = await utils.scrape('paginated-json')
+    t.pass('scrape succeeded')
+  }
+  catch (err) {
+    t.fail(err)
+  }
+
+  const expected = [
+    { date: 'Jan 1', cases: 1, deaths: 5 },
+    { date: 'Jan 2', cases: 2, deaths: 5 },
+    { date: 'Jan 2', cases: 3, deaths: 5 }
+  ]
+  utils.validateResults(t, fullResult, expected)
+
+  await utils.teardown()
+  t.end()
+})
+
+
+// TODO tests for paginated
+// scrape gets latest set of paginated files
+// timeseries scrape gets latest set of paginated files
+// lots of pages (> 10) should still work for selecting all the pages

--- a/tests/integration/events/scraper/paginated-json-test.js
+++ b/tests/integration/events/scraper/paginated-json-test.js
@@ -6,17 +6,18 @@ const testCache = require('../../_lib/testcache.js')
 
 const firstPage = {
   records: [
-    { date: 'Jan 1', cases: 1 },
-    { date: 'Jan 2', cases: 2 }
+    { counter: 'a1', cases: 1 },
+    { counter: 'a2', cases: 2 }
   ],
   nextUrl: 'http://localhost:5555/tests/fake-source-urls/paginated-json/page2.json'
 }
 
 const lastPage = {
   records: [
-    { date: 'Jan 3', cases: 3 }
+    { counter: 'a3', cases: 3 }
   ]
 }
+
 
 async function doCrawl (t) {
   try {
@@ -29,7 +30,7 @@ async function doCrawl (t) {
   }
 }
 
-test.only('scrape completes successfully', async t => {
+test('scrape completes successfully', async t => {
   await utils.setup()
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
@@ -71,9 +72,9 @@ test('scrape gets all pages of data', async t => {
   }
 
   const expected = [
-    { date: 'Jan 1', cases: 1, deaths: 5 },
-    { date: 'Jan 2', cases: 2, deaths: 5 },
-    { date: 'Jan 2', cases: 3, deaths: 5 }
+    { counter: 'a1', cases: 1, deaths: 5 },
+    { counter: 'a2', cases: 2, deaths: 5 },
+    { counter: 'a3', cases: 3, deaths: 5 }
   ]
   utils.validateResults(t, fullResult, expected)
 

--- a/tests/integration/events/scraper/paginated-json-test.js
+++ b/tests/integration/events/scraper/paginated-json-test.js
@@ -2,6 +2,8 @@ process.env.NODE_ENV = 'testing'
 
 const utils = require('../utils.js')
 const test = require('tape')
+const fs = require('fs')
+const path = require('path')
 const testCache = require('../../_lib/testcache.js')
 
 const firstPage = {
@@ -82,6 +84,44 @@ test('scrape gets all pages of data', async t => {
   t.end()
 })
 
+/** arcgis (e.g., JP) was first added to this project before
+ * pagination support was added, so one of their data sources
+ * (e.g. 'default') has already been saved into the cache as
+ * `{datetime}-default-{sha}.{ext}.gz`.  We want to scrape that with
+ * the same code, because the page format hasn't changed.  So, allow
+ * `-default-{sha}` to be scraped as if it was paginated as
+ * `-default-0-`. */
+test('scrape can handle a cached first page with no pagination number', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('paginated-json/page1.json', lastPage)
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
+  await doCrawl(t)
+  t.equal(2, testCache.allFiles().length, 'all files after crawl.')
+
+  const cachedCases = testCache.allFiles().filter(f => f.match(/-cases-0-/))
+  t.equal(cachedCases.length, 1, 'single cases file')
+  const f = path.join(testCache.testingCache, cachedCases[0])
+  fs.renameSync(f, f.replace('-cases-0-', '-cases-'))
+
+  let fullResult
+  try {
+    fullResult = await utils.scrape('paginated-json')
+    t.pass('scrape succeeded')
+  }
+  catch (err) {
+    t.fail(err)
+    t.fail(err.stack)
+  }
+
+  const expected = [
+    { counter: 'a3', cases: 3, deaths: 5 }
+  ]
+  utils.validateResults(t, fullResult, expected)
+
+  await utils.teardown()
+  t.end()
+})
 
 // TODO tests for paginated
 // scrape gets latest set of paginated files

--- a/tests/integration/events/scraper/paginated-json-test.js
+++ b/tests/integration/events/scraper/paginated-json-test.js
@@ -25,10 +25,33 @@ async function doCrawl (t) {
   }
   catch (err) {
     t.fail(err)
+    t.fail(err.stack)
   }
 }
 
-test.only('scrape gets all pages of data', async t => {
+test.only('scrape completes successfully', async t => {
+  await utils.setup()
+
+  utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
+  utils.writeFakeSourceContent('paginated-json/page2.json', lastPage)
+  utils.writeFakeSourceContent('paginated-json/deaths.json', { deaths: 5 })
+  await doCrawl(t)
+  t.equal(3, testCache.allFiles().length, 'sanity check, all files after crawl.')
+
+  try {
+    await utils.scrape('paginated-json')
+    t.pass('scrape succeeded')
+  }
+  catch (err) {
+    t.fail(err)
+    t.fail(err.stack)
+  }
+
+  await utils.teardown()
+  t.end()
+})
+
+test('scrape gets all pages of data', async t => {
   await utils.setup()
 
   utils.writeFakeSourceContent('paginated-json/page1.json', firstPage)
@@ -61,5 +84,6 @@ test.only('scrape gets all pages of data', async t => {
 
 // TODO tests for paginated
 // scrape gets latest set of paginated files
+// scrape gets correct set of paginated files
 // timeseries scrape gets latest set of paginated files
 // lots of pages (> 10) should still work for selecting all the pages

--- a/tests/integration/events/scraper/paginated-json-test.js
+++ b/tests/integration/events/scraper/paginated-json-test.js
@@ -136,8 +136,3 @@ test('can scrape many pages', async t => {
   await utils.teardown()
   t.end()
 })
-
-// TODO tests for paginated
-// scrape gets latest set of paginated files
-// scrape gets correct set of paginated files
-// timeseries scrape gets latest set of paginated files

--- a/tests/integration/events/utils.js
+++ b/tests/integration/events/utils.js
@@ -91,11 +91,42 @@ async function scrape (sourceKey) {
   return fullResult
 }
 
+function validateResults (t, fullResult, expected) {
+  t.ok(fullResult, 'Have fullResult')
+  if (!fullResult)
+    return
+
+  const actual = fullResult[0].data
+  t.ok(actual, 'Have data')
+  if (!actual)
+    return
+
+  t.equal(expected.length, actual.length, `Result length; got actual = ${JSON.stringify(actual, null, 2)}`)
+
+  // Only look at fields in actual record where the keys match those
+  // in expected.
+  function pruneActual (actualRec, expectedRec) {
+    return Object.keys(expectedRec).reduce((hsh, key) => {
+      hsh[key] = actualRec[key]
+      return hsh
+    }, {})
+  }
+
+  const maxLen = Math.min(expected.length, actual.length)
+  const inspectActual = actual.
+        slice(0, maxLen).
+        map((rec, index) => pruneActual(rec, expected[index]))
+  expected.slice(0, maxLen).forEach((rec, index) => {
+    t.deepEqual(rec, inspectActual[index], `${index} exact key matches`)
+  })
+}
+
 module.exports = {
   setup,
   teardown,
   writeFakeSourceContent,
   copyFixture,
   crawl,
-  scrape
+  scrape,
+  validateResults
 }

--- a/tests/integration/events/utils.js
+++ b/tests/integration/events/utils.js
@@ -36,25 +36,22 @@ async function setup () {
  * is thrown.  If unhandled, this crashes the Node process,
  * including tape, so we'll ignore just these errors for the sake of
  * testing. */
-function ignoreSandboxUncaughtExceptions () {
-  process.on('uncaughtException', err => {
-    const ignoreExceptions = [
-      `connect ECONNRESET 127.0.0.1:${sandboxPort + 1}`,
-      `connect ECONNREFUSED 127.0.0.1:${sandboxPort + 1}`
-    ]
-    if (ignoreExceptions.includes(err.message)) {
-      // const msg = `(Ignoring sandbox "${err.message}" thrown during teardown)`
-      // console.error(msg)
-    }
-    else
-      throw err
-  })
-}
+process.on('uncaughtException', err => {
+  const ignoreExceptions = [
+    `connect ECONNRESET 127.0.0.1:${sandboxPort + 1}`,
+    `connect ECONNREFUSED 127.0.0.1:${sandboxPort + 1}`
+  ]
+  if (ignoreExceptions.includes(err.message)) {
+    // const msg = `(Ignoring sandbox "${err.message}" thrown during teardown)`
+    // console.error(msg)
+  }
+  else
+    throw err
+})
 
 async function teardown () {
   fakeCrawlSites.deleteAllFiles()
   testCache.teardown()
-  ignoreSandboxUncaughtExceptions()
   await sandbox.end()
 }
 

--- a/tests/integration/fake-sources/sources/multiple-urls.js
+++ b/tests/integration/fake-sources/sources/multiple-urls.js
@@ -23,10 +23,10 @@ module.exports = {
         }
       ],
       scrape ( { cases, deaths } ) {
-        return {
+        return [ {
           cases: cases.count,
           deaths: deaths.count
-        }
+        } ]
       }
     }
   ]

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -33,13 +33,12 @@ module.exports = {
         },
       ],
       scrape ({ cases, deaths }) {
-        assert(Array.isArray(cases, 'cases are paginated, should be an Array.'))
+        assert(Array.isArray(cases, 'paginated data should be passed in as Array.'))
+
         const result = []
-        for (let i = 0; i <= cases.length; ++i) {
-          cases[i].forEach(body => {
-            body.records.forEach(rec => {
-              result.push( { date: rec.date, cases: rec.cases, deaths: deaths.deaths, page: i } )
-            })
+        for (let i = 0; i < cases.length; i++) {
+          cases[i].records.forEach(rec => {
+            result.push( { date: rec.date, cases: rec.cases, deaths: deaths.deaths, page: i } )
           })
         }
         return result

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -17,9 +17,8 @@ module.exports = {
             let currentUrl = 'http://localhost:5555/tests/fake-source-urls/paginated-json/page1.json'
             while (currentUrl) {
               let { body } = await client( { url: currentUrl } )
-              body = JSON.parse(body)
               result.push(body)
-              currentUrl = body.nextUrl
+              currentUrl = JSON.parse(body).nextUrl
             }
             return result
           }

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -16,8 +16,8 @@ module.exports = {
             const result = []
             let currentUrl = 'http://localhost:5555/tests/fake-source-urls/paginated-json/page1.json'
             while (currentUrl) {
-              let { body } = await client( { url: body.nextUrl } )
-              body = JSON.parse(`body`)
+              let { body } = await client( { url: currentUrl } )
+              body = JSON.parse(body)
               result.push(body)
               currentUrl = body.nextUrl
             }

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -1,3 +1,5 @@
+const assert = require('assert')
+
 module.exports = {
   country: 'iso1:US',
   state: 'CA',
@@ -31,6 +33,7 @@ module.exports = {
         },
       ],
       scrape ({ cases, deaths }) {
+        assert(Array.isArray(cases, 'cases are paginated, should be an Array.'))
         const result = []
         for (let i = 0; i <= cases.length; ++i) {
           cases[i].forEach(body => {

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -11,6 +11,7 @@ module.exports = {
       startDate: '2020-03-01',
       crawl: [
         {
+          name: 'cases',
           type: 'json',
           paginated: async client => {
             const result = []
@@ -22,14 +23,19 @@ module.exports = {
             }
             return result
           }
-        }
+        },
+        {
+          name: 'deaths',
+          type: 'json',
+          url: 'http://localhost:5555/tests/fake-source-urls/paginated-json/deaths.json'
+        },
       ],
-      scrape (json) {
+      scrape ({ cases, deaths }) {
         const result = []
-        for (let i = 0; i <= json.length; ++i) {
-          json[i].forEach(body => {
+        for (let i = 0; i <= cases.length; ++i) {
+          cases[i].forEach(body => {
             body.records.forEach(rec => {
-              result.push( { date: rec.date, cases: rec.cases, page: i } )
+              result.push( { date: rec.date, cases: rec.cases, deaths: deaths.deaths, page: i } )
             })
           })
         }

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -27,8 +27,10 @@ module.exports = {
       scrape (json) {
         const result = []
         for (let i = 0; i <= json.length; ++i) {
-          json[i].forEach(rec => {
-            result.push( { date: rec.date, cases: rec.cases, page: i } )
+          json[i].forEach(body => {
+            body.records.forEach(rec => {
+              result.push( { date: rec.date, cases: rec.cases, page: i } )
+            })
           })
         }
         return result

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -17,9 +17,11 @@ module.exports = {
           type: 'json',
           paginated: async client => {
             const result = []
-            let currentUrl = 'http://localhost:5555/tests/fake-source-urls/paginated-json/page1.json'
+            const baseUrl = 'http://localhost:5555/tests/fake-source-urls/paginated-json'
+            let currentUrl = 'page1.json'
             while (currentUrl) {
-              let { body } = await client( { url: currentUrl } )
+              const url = `${baseUrl}/${currentUrl}`
+              let { body } = await client( { url } )
               result.push(body)
               currentUrl = JSON.parse(body).nextUrl
             }

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -1,0 +1,39 @@
+module.exports = {
+  country: 'iso1:US',
+  state: 'CA',
+  maintainers: [],
+  friendly: {
+    name: 'Canadian COVID Rolling Task Force',
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  },
+  scrapers: [
+    {
+      startDate: '2020-03-01',
+      crawl: [
+        {
+          type: 'json',
+          paginated: async client => {
+            const result = []
+            let currentUrl = 'http://localhost:5555/tests/fake-source-urls/paginated-json/page1.json'
+            while (currentUrl) {
+              let { body } = await client( { url: body.nextUrl } )
+              body = JSON.parse(`body`)
+              result.push(body)
+              currentUrl = body.nextUrl
+            }
+            return result
+          }
+        }
+      ],
+      scrape (json) {
+        const result = []
+        for (let i = 0; i <= json.length; ++i) {
+          json[i].forEach(rec => {
+            result.push( { date: rec.date, cases: rec.cases, page: i } )
+          })
+        }
+        return result
+      }
+    }
+  ]
+}

--- a/tests/integration/fake-sources/sources/paginated-json.js
+++ b/tests/integration/fake-sources/sources/paginated-json.js
@@ -38,7 +38,7 @@ module.exports = {
         const result = []
         for (let i = 0; i < cases.length; i++) {
           cases[i].records.forEach(rec => {
-            result.push( { date: rec.date, cases: rec.cases, deaths: deaths.deaths, page: i } )
+            result.push( { counter: rec.counter, cases: rec.cases, deaths: deaths.deaths, page: i } )
           })
         }
         return result

--- a/tests/unit/crawler/cache/_cache-namer-test.js
+++ b/tests/unit/crawler/cache/_cache-namer-test.js
@@ -28,7 +28,7 @@ test('Generate some filenames', t => {
   let data = Buffer.from('hi there')
   let type = 'page'
   let params = { _sourceKey, _name, data, type }
-  let { filepath, filename } = cacheNamer(params)
+  let { filepath, filename } = cacheNamer(now.toISOString(), params)
 
   // Filepath
   let parts = filepath.split('/')
@@ -61,7 +61,7 @@ test('Generate some filenames', t => {
   type = 'json'
   params = { _sourceKey, _name, data, type }
 
-  ;({ filename } = cacheNamer(params))
+  ;({ filename } = cacheNamer(now.toISOString(), params))
   parts = filename.split('-')
   t.equal(parts[3], _name, 'name matches')
   t.equal(parts[4].split('.')[0], '0f112', 'Hash appended')

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -91,7 +91,7 @@ test('validateSource catches problems', t => {
     '2020-03-02: Duplicate crawler name \'cases\'; names must be unique',
     '2020-03-02: Invalid crawler.data \'trash\'; must be one of: table, list, paragraph',
     '2020-03-01: Invalid crawler.type \'text\'; must be one of: page, headless, csv, tsv, pdf, json, raw',
-    '2020-03-01: Require url or paginated, not both',
+    '2020-03-01: Crawler must have either url or paginated, but not both',
     '2020-03-01: Crawler paginated must be an async function',
     'Scraper must contain a startDate',
     '2020-03-03: Single crawler must not have a name key',

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -46,7 +46,12 @@ test('validateSource catches problems', t => {
     scrapers: [
       {
         startDate: '2020-03-01',
-        crawl: [ { type: 'text' /* bad type */, url: 'https://somedata.csv' } ],
+        crawl: [
+          { type: 'text' /* bad type */,
+            url: 'https://somedata.csv',
+            /* Can't have url and paginated, pag. must be async. */
+            paginated: client => { return [ client.get(123) ] }
+          } ],
         scrape (data) { return { cases: data.cases } }
       },
       {
@@ -86,6 +91,8 @@ test('validateSource catches problems', t => {
     '2020-03-02: Duplicate crawler name \'cases\'; names must be unique',
     '2020-03-02: Invalid crawler.data \'trash\'; must be one of: table, list, paragraph',
     '2020-03-01: Invalid crawler.type \'text\'; must be one of: page, headless, csv, tsv, pdf, json, raw',
+    '2020-03-01: Require url or paginated, not both',
+    '2020-03-01: Crawler paginated must be an async function',
     'Scraper must contain a startDate',
     '2020-03-03: Single crawler must not have a name key',
     '(missing startDate): Single crawler must not have a name key'

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 const test = require('tape')
 
 const sut = join(process.cwd(), 'src', 'shared', 'utils', 'parse-cache-filename.js')
-const parse = require(sut)
+const { parse } = require(sut)
 
 // This tests the filenames of files coming out of the cache
 // To see how we ensure the filenames going into the cache are correct

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -125,7 +125,7 @@ const files = [
   'D2-dog-0',  // first in set
 ].map(properCacheName)
 
-test.only('matchName returns all matches', t => {
+test('matchName returns all matches', t => {
   const testCases = [
     [ 'apple', [ 'D1-apple', 'D2-apple' ], 'regular key' ],
     [ 'bear', [ 'D1-bear', 'D2-bear' ], 'regular key 2' ],

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -123,6 +123,7 @@ const files = [
   'D2-cat-2',  // bad set
   'D2-cat-3',
   'D2-dog-0',  // first in set
+  'bad-file-here'  // ignore this!
 ].map(properCacheName)
 
 test('matchName returns all matches', t => {

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 const test = require('tape')
 
 const sut = join(process.cwd(), 'src', 'shared', 'utils', 'parse-cache-filename.js')
-const { parse } = require(sut)
+const { parse, matchName } = require(sut)
 
 // This tests the filenames of files coming out of the cache
 // To see how we ensure the filenames going into the cache are correct
@@ -97,5 +97,44 @@ test('Filenames (with file paths) with missing or bad sha throws', t => {
     const f = join('folder', 'subfolder', s)
     t.throws(() => parse(f), `${n} sha throws`)
   })
+  t.end()
+})
+
+
+/**
+ * Match name tests.
+ */
+
+function properCacheName (s) {
+  const tmp = s.replace('D1', '2020-01-01t01_00_00.000z').
+        replace('D2', '2020-22-22t22_22_22.000z')
+  return `${tmp}-aaaaa.html.gz`
+}
+
+const files = [
+  'D1-apple',
+  'D1-bear',
+  'D1-cat-0',  // first in set
+  'D1-cat-1',
+  'D1-dog',    // first in set
+  'D1-dog-1',
+  'D2-apple',
+  'D2-bear',
+  'D2-cat-2',  // bad set
+  'D2-cat-3',
+  'D2-dog-0',  // first in set
+].map(properCacheName)
+
+test.only('matchName returns all matches', t => {
+  const expected = [ 'D1-apple', 'D2-apple' ].map(properCacheName)
+  t.deepEqual(matchName('apple', files), expected)
+  t.end()
+})
+
+test('matchName return first page in set', t => {
+  t.end()
+})
+
+test('matchName returns empty if no matches', t => {
   t.end()
 })

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -126,15 +126,17 @@ const files = [
 ].map(properCacheName)
 
 test.only('matchName returns all matches', t => {
-  const expected = [ 'D1-apple', 'D2-apple' ].map(properCacheName)
-  t.deepEqual(matchName('apple', files), expected)
-  t.end()
-})
-
-test('matchName return first page in set', t => {
-  t.end()
-})
-
-test('matchName returns empty if no matches', t => {
+  const testCases = [
+    [ 'apple', [ 'D1-apple', 'D2-apple' ], 'regular key' ],
+    [ 'bear', [ 'D1-bear', 'D2-bear' ], 'regular key 2' ],
+    [ 'cat', [ 'D1-cat-0' ], 'paged, only first page is returned' ],
+    [ 'dog', [ 'D1-dog', 'D2-dog-0' ], 'paged, first returned, incl. no page number' ]
+  ]
+  testCases.forEach(c => {
+    const [ key, expected, msg ] = [ ...c ]
+    const actual = matchName(key, files)
+    console.log(actual.join())
+    t.deepEqual(actual, expected.map(properCacheName), msg)
+  })
   t.end()
 })

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -22,6 +22,19 @@ test('parsing', t => {
   t.end()
 })
 
+test('filename does not have to end with gz', t => {
+  const filename = '2020-04-11t21_00_00.000z-default-117bb.html'
+  const p = parse(filename)
+  const expected = {
+    datetime: '2020-04-11t21_00_00.000z',
+    name: 'default',
+    sha: '117bb',
+    extension: 'html'
+  }
+  t.deepEqual(p, expected)
+  t.end()
+})
+
 test('Filename can have page counter after the cache key', t => {
   const baseExpected = {
     datetime: '2020-04-11t21_00_00.000z',
@@ -69,15 +82,6 @@ test('Filenames (with file paths) with Bad cache filename throws', t => {
     t.pass('Caught bad cache filename')
   }
   t.end()
-})
-
-test('Filenames with bad / missing extension throws', t => {
-  const badexts = [ '', 'htm', 'UpperCase', '123' ]
-  t.plan(badexts.length)
-  badexts.forEach(n => {
-    const filename = `2020-04-11t21_00_00.000z-default-117bb.${n}`
-    t.throws(() => parse(filename), `${n} ext throws`)
-  })
 })
 
 test('Filenames (with file paths) with bad keys throws', t => {

--- a/tests/unit/shared/utils/parse-cache-filename-test.js
+++ b/tests/unit/shared/utils/parse-cache-filename-test.js
@@ -1,0 +1,101 @@
+const { join } = require('path')
+const test = require('tape')
+
+const sut = join(process.cwd(), 'src', 'shared', 'utils', 'parse-cache-filename.js')
+const parse = require(sut)
+
+// This tests the filenames of files coming out of the cache
+// To see how we ensure the filenames going into the cache are correct
+// SEE: `tests/unit/crawler/cache/_cache-namer-test.js`
+
+
+test('parsing', t => {
+  const filename = '2020-04-11t21_00_00.000z-default-117bb.html.gz'
+  const p = parse(filename)
+  const expected = {
+    datetime: '2020-04-11t21_00_00.000z',
+    name: 'default',
+    sha: '117bb',
+    extension: 'html'
+  }
+  t.deepEqual(p, expected)
+  t.end()
+})
+
+test('Filename can have page counter after the cache key', t => {
+  const baseExpected = {
+    datetime: '2020-04-11t21_00_00.000z',
+    name: 'default',
+    sha: '117bb',
+    extension: 'html'
+  }
+  for (let i = 0; i < 13; i++) {
+    const filename = `2020-04-11t21_00_00.000z-default-${i}-117bb.html.gz`
+    const p = parse(filename)
+    const expected = { ...baseExpected, page: i }
+    t.deepEqual(p, expected, filename)
+  }
+  t.end()
+})
+
+test('Filename page counter must be a number', t => {
+  try {
+    const filename = `2020-04-11t21_00_00.000z-default-BAD-117bb.html.gz`
+    parse(filename)
+    t.fail('should have thrown')
+  } catch (err) {
+    t.pass('Caught bad cache filename, err = ' + err)
+  }
+  t.end()
+})
+
+test('Filenames with bad date throws', t => {
+  // Note missing a digit before the timezone.
+  const filename = '2020-04-11t21_00_00.00z-default-117bb.html.gz'
+  try {
+    parse(filename)
+    t.fail('should have thrown')
+  } catch (err) {
+    t.pass('Caught bad cache filename')
+  }
+  t.end()
+})
+
+test('Filenames (with file paths) with Bad cache filename throws', t => {
+  try {
+    parse('bad_filename')
+    t.fail('should have thrown')
+  } catch (err) {
+    t.pass('Caught bad cache filename')
+  }
+  t.end()
+})
+
+test('Filenames with bad / missing extension throws', t => {
+  const badexts = [ '', 'htm', 'UpperCase', '123' ]
+  t.plan(badexts.length)
+  badexts.forEach(n => {
+    const filename = `2020-04-11t21_00_00.000z-default-117bb.${n}`
+    t.throws(() => parse(filename), `${n} ext throws`)
+  })
+})
+
+test('Filenames (with file paths) with bad keys throws', t => {
+  const badnames = [ '', 'has space', 'UpperCase', '123' ]
+  badnames.forEach(n => {
+    const s = `2020-04-11t21_00_00.000z-${n}-117bb.html.gz`
+    const f = join('folder', 'subfolder', s)
+    t.throws(() => parse(f), `${n} name throws`)
+  })
+  t.end()
+})
+
+test('Filenames (with file paths) with missing or bad sha throws', t => {
+  const badshas = [ '', '12 34', 'UPPER', '123' ]
+  badshas.forEach(n => {
+    const s = `2020-04-11t21_00_00.000z-default-${n}.html.gz`
+    const f = join('folder', 'subfolder', s)
+    t.throws(() => parse(f), `${n} sha throws`)
+  })
+  t.end()
+})

--- a/tests/unit/shared/utils/validate-cache-filename-test.js
+++ b/tests/unit/shared/utils/validate-cache-filename-test.js
@@ -8,10 +8,8 @@ const validate = require(sut)
 // To see how we ensure the filenames going into the cache are correct
 // SEE: `tests/unit/crawler/cache/_cache-namer-test.js`
 
-test('Module exists', t => {
-  t.plan(1)
-  t.ok(validate, 'validate module exists')
-})
+// This uses parse-cache-filename, so most of the scenarios are
+// covered already in parse-cache-filename-test.
 
 test('Date parsed correctly', t => {
   t.plan(1)
@@ -20,61 +18,11 @@ test('Date parsed correctly', t => {
   t.pass('We good')
 })
 
-test('Filename can have page counter after the cache key', t => {
-  t.plan(1)
-  for (let i = 0; i < 13; i++) {
-    const filename = `2020-04-11t21_00_00.000z-default-${i}-117bb.html.gz`
-    validate(filename)
-  }
-  t.pass('We good')
-})
-
-test('Filename page counter must be a number', t => {
-  t.plan(1)
-  try {
-    const filename = `2020-04-11t21_00_00.000z-default-BAD-117bb.html.gz`
-    validate(filename)
-    t.fail('should have thrown')
-  } catch (err) {
-    t.pass('Caught bad cache filename, err = ' + err)
-  }
-})
-
-test('Filenames (with file paths) with Bad cache filename throws', t => {
-  t.plan(1)
-  try {
-    validate('bad_filename')
-    t.fail('should have thrown')
-  } catch (err) {
-    t.pass('Caught bad cache filename')
-  }
-})
-
 test('Filenames with bad / missing extension throws', t => {
   const badexts = [ '', 'htm', 'UpperCase', '123' ]
   t.plan(badexts.length)
   badexts.forEach(n => {
     const filename = `2020-04-11t21_00_00.000z-default-117bb.${n}`
     t.throws(() => validate(filename), `${n} ext throws`)
-  })
-})
-
-test('Filenames (with file paths) with bad keys throws', t => {
-  const badnames = [ '', 'has space', 'UpperCase', '123' ]
-  t.plan(badnames.length)
-  badnames.forEach(n => {
-    const s = `2020-04-11t21_00_00.000z-${n}-117bb.html.gz`
-    const f = join('folder', 'subfolder', s)
-    t.throws(() => validate(f), `${n} name throws`)
-  })
-})
-
-test('Filenames (with file paths) with missing or bad sha throws', t => {
-  const badshas = [ '', '12 34', 'UPPER', '123' ]
-  t.plan(badshas.length)
-  badshas.forEach(n => {
-    const s = `2020-04-11t21_00_00.000z-default-${n}.html.gz`
-    const f = join('folder', 'subfolder', s)
-    t.throws(() => validate(f), `${n} sha throws`)
   })
 })

--- a/tests/unit/shared/utils/validate-cache-filename-test.js
+++ b/tests/unit/shared/utils/validate-cache-filename-test.js
@@ -20,6 +20,26 @@ test('Date parsed correctly', t => {
   t.pass('We good')
 })
 
+test('Filename can have page counter after the cache key', t => {
+  t.plan(1)
+  for (let i = 0; i < 13; i++) {
+    const filename = `2020-04-11t21_00_00.000z-default-${i}-117bb.html.gz`
+    validate(filename)
+  }
+  t.pass('We good')
+})
+
+test('Filename page counter must be a number', t => {
+  t.plan(1)
+  try {
+    const filename = `2020-04-11t21_00_00.000z-default-BAD-117bb.html.gz`
+    validate(filename)
+    t.fail('should have thrown')
+  } catch (err) {
+    t.pass('Caught bad cache filename, err = ' + err)
+  }
+})
+
 test('Filenames (with file paths) with Bad cache filename throws', t => {
   t.plan(1)
   try {


### PR DESCRIPTION
WIP

# Example

JP, old unpaginated code:

`./start --scrape jp`

Result:

```
Local cache miss, attempting to pull cache from S3
S3 cache hit for: jp / 2020-05-28
```

(index) │  state    │ cases 
--- | --- | --- 
0  │ 'iso2:JP-23'  │ 382
1  │ 'iso2:JP-28'  │ 481
2  │ 'iso2:JP-01'  │ 387
44  │ 'iso2:JP-31' │  1 
45  │ 'iso2:JP-32' │  7  
46  │              │ 6515 

Scrape: jp / 2020-05-28: 3869.864ms


JP With new paginated code

`./start --crawl jp`

```
... getting offset 0
... getting offset 10000
returning 2 pages, type = object
Wrote to local cache: /Users/jeff/Documents/Projects/li/crawler-cache/jp/2020-05-27/2020-05-27t22_12_54.822z-default-0-1d130.json.gz
Wrote to local cache: /Users/jeff/Documents/Projects/li/crawler-cache/jp/2020-05-27/2020-05-27t22_12_54.822z-default-1-18264.json.gz
Crawl jp: 25429.925ms
```

`./start --scrape jp`

```
all pages in set = 2020-05-27t22_12_54.822z-default-0-1d130.json.gz,2020-05-27t22_12_54.822z-default-1-18264.json.gz
Local cache hit for: jp / 2020-05-28
Loading 2 pages of data
```

(index) │  state   │ cases 
--- | --- | --- 
0  │ 'iso2:JP-23'  │ 504 
1  │ 'iso2:JP-28'  │ 698 
2  │ 'iso2:JP-01'  │ 990 
3  │ 'iso2:JP-10'  │ 108 
44  │ 'iso2:JP-31' │  3  
45  │ 'iso2:JP-32' │ 15  
46  │              │ 9512 


