### PR TITLE
fix AU-NT name to schema key mapping

### DIFF
--- a/src/shared/sources/au/nt/index.js
+++ b/src/shared/sources/au/nt/index.js
@@ -1,10 +1,9 @@
-const assert = require('assert')
 const maintainers = require('../../_lib/maintainers.js')
 const parse = require('../../_lib/parse.js')
 
 const schemaKeysByHeadingFragment = {
   'confirmed cases': 'cases',
-  'active cases': 'cases',
+  'active cases': 'active',
   'people recovered': 'recovered',
   'tests conducted': 'tested'
 }
@@ -41,7 +40,6 @@ module.exports = {
             data[key] = parse.number(value)
           }
         })
-        assert(data.cases > 0, 'Cases are not reasonable')
         return data
       }
     }


### PR DESCRIPTION
- Active cases means Active not Cases.
- At the moment theres no 'cases' so have to
  remove the assertion so we can still see the other data.
