### PR TITLE
Scrapers must be in startDate order.

### DIFF
--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -17,9 +17,9 @@ module.exports = async function crawl (event) {
     console.time(timeLabel)
 
     /**
-     * Select the current scraper from the source's available scrapers
+     * Select the current scraper from the source's available scrapers.
+     * Scrapers are guaranteed to be in startDate order.
      */
-    // TODO actually calculate latest start date; this hack works for now
     const scraper = scrapers[scrapers.length - 1]
 
     /**

--- a/src/shared/sources/_lib/validate-source.js
+++ b/src/shared/sources/_lib/validate-source.js
@@ -52,6 +52,10 @@ function validateSource (source) {
   requirement(is.array(scrapers), 'Scrapers must be an array')
   requirement(scrapers.length, 'Scrapers must have at least one scraper')
 
+  const startDates = scrapers.map(s => s.startDate).filter(s => s !== undefined)
+  const sortedStartDates = new Array(...startDates).sort()
+  requirement(startDates.join() === sortedStartDates.join(), 'Scrapers must be ordered by startDate')
+
   // Now look inside each scraper
   for (const scraper of scrapers) {
     const { startDate, crawl, scrape } = scraper


### PR DESCRIPTION
Currently the code picks the latest crawl by assuming that the scrapers are in startDate order; this PR ensures that's correct.

Replaces https://github.com/covidatlas/li/pull/103