### PR TITLE
Source status http endpoint

### DIFF
--- a/.arc
+++ b/.arc
@@ -15,7 +15,7 @@ get /get/headless
 # API (api.covidatlas.com)
 get /locations
 get /locations/:location
-
+get /status
 
 @events
 crawler     # Crawls our sources

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,45 @@
 <html>
-<body>
-  <p>Welcome to li.</p>
-  <p>Content to come.</p>
-</body>
+  <style>
+    body {
+        font-family: Arial;
+    }
+
+    table {
+        border-spacing: 5px;
+    }
+
+    th, td {
+        text-align: left;
+    }
+  </style>
+  <body>
+    <h1>Welcome to Li.</h1>
+    <table>
+      <tr>
+        <th>
+          Item
+        </th>
+        <th>
+          URL
+        </th>
+      </tr>
+      <tr>
+        <td>
+          Locations
+        </td>
+        <td>
+          <a href='locations'>json</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Scraper status
+        </td>
+        <td>
+          <a href='status?format=html'>html</a>
+          <a href='status?format=html'>json</a>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/src/events/status/index.js
+++ b/src/events/status/index.js
@@ -22,6 +22,9 @@ async function updateStatus (params) {
     let newStatus = Object.assign({}, lastStatus)
     newStatus.status = status
 
+    if (status === 'success')
+      newStatus.last_success = new Date().toISOString()
+
     /**
      * Refresh consecutive
      */

--- a/src/http/get-status/.arc-config
+++ b/src/http/get-status/.arc-config
@@ -1,0 +1,3 @@
+@aws
+runtime nodejs12.x
+memory 1152

--- a/src/http/get-status/index.js
+++ b/src/http/get-status/index.js
@@ -1,0 +1,37 @@
+const arc = require('@architect/functions')
+
+/**
+ * Returns an array of statuses currently in the system
+ */
+// TODO status monitoring
+// Ref https://github.com/covidatlas/li/issues/234
+// Should provide the source data for a simple page
+// | source | status (up || down) | last successful crawl | last successful scrape | error message (if status = down) |
+async function getStatus () {
+  const data = await arc.tables()
+
+  // Running log
+  const result = await data.status.scan({})
+  const statuses = result.Items // .map(i => { return { source: i.source, event: i.event } } )
+
+  // TODO:
+  // - extract latest crawl, latest scrape for source, join together
+  // - extract data from history for last successful crawl, last successful scrape, if current status !== success
+  // - see if can store error message in the tables
+  // - link to raw logs?
+
+  /*
+  // Past history
+  const statusLogResult = await data['status-logs'].scan({})
+  const slogs = statusLogResult.Items // .map(i => { return { source: i.source, ts: i.ts } } )
+  */
+
+  return {
+    json: statuses,
+    headers: {
+      'cache-control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0'
+    }
+  }
+}
+
+exports.handler = arc.http.async(getStatus)

--- a/src/http/get-status/index.js
+++ b/src/http/get-status/index.js
@@ -11,24 +11,127 @@ async function getStatus () {
   const data = await arc.tables()
 
   // Running log
-  const result = await data.status.scan({})
-  const statuses = result.Items // .map(i => { return { source: i.source, event: i.event } } )
+  const statuses = await data.status.scan({}).then(result => result.Items)
 
-  // TODO:
-  // - extract latest crawl, latest scrape for source, join together
-  // - extract data from history for last successful crawl, last successful scrape, if current status !== success
-  // - see if can store error message in the tables
-  // - link to raw logs?
+  // Past history.
+  // TODO: improve the query to only return the last success.
+  // This is returning the full data and then using lastSuccess() to get the last success.
+  const logs = await data['status-logs'].scan({}).then(result => result.Items)
 
-  /*
-  // Past history
-  const statusLogResult = await data['status-logs'].scan({})
-  const slogs = statusLogResult.Items // .map(i => { return { source: i.source, ts: i.ts } } )
-  */
+  function lastSuccess (source, e) {
+    const success = sl => (sl.source === source && sl.event === e && sl.status === 'success')
+    const successes = logs.filter(success)
+    if (successes.length === 0)
+      return null
+    const t = successes.map(s => s.ts).sort().slice(-1)[0]
+    return t.replace('T', ' ').replace(/\..+/, '')
+  }
+
+  function eventDetails (source, e) {
+    const currStatus = statuses.find(st => st.source === source && st.event === e) || {}
+    currStatus.last_success = lastSuccess(source, e)
+    return [ 'status', 'consecutive', 'last_success' ].reduce((hsh, f) => {
+      return { ...hsh, [`${e}_${f}`]: currStatus[f] || null }
+    }, {} )
+  }
+
+  const sources = [ ...new Set(statuses.map(s => s.source)) ].sort()
+
+  // TODO (status) store error message in the tables
+  // TODO (status) add link to raw logs?
+  const summary = sources.map(source => {
+    return {
+      source,
+      ...eventDetails(source, 'crawler'),
+      ...eventDetails(source, 'scraper')
+    }
+  }).map(d => {
+    const status = [ d.crawler_status, d.scraper_status ].
+          includes('failed') ? 'failed' : 'success'
+    return {
+      ...d,
+      status
+    }
+  })
+
+  // TODO (status) generate HTML using some kind of templating engine.
+  // Hacking to get HTML output for now, to be replaced w/ whatever
+  // templating method we choose.
+  const fields = [
+    'source', 'status',
+    'crawler_status', 'crawler_consecutive', 'crawler_last_success',
+    'scraper_status', 'scraper_consecutive', 'scraper_last_success'
+  ]
+
+  const ths = fields.map(f => `<th>${f.replace(/_/g, ' ')}</th>`).join('')
+  const trs = summary.map(d => {
+    const tr = fields.map(f => `<td>${ d[f] || '&nbsp;' }</td>`).join('')
+    return `<tr class='${d.status}'>${tr}</tr>`
+  })
+
+  const response_body = `
+<html>
+
+<style>
+h1 {
+  font-family: Arial;
+}
+
+th, td {
+  padding: 5px;
+  text-align: left;
+  /* font-family: sans-serif; */
+  border-bottom: 1px solid #ddd;
+}
+
+tr:hover { background-color: #f5f5f5; }
+
+.success { color:green; }
+
+.failed { color:red; }
+</style>
+
+<body>
+<h1>Source Statuses</h1>
+<pre><code>
+
+<table style='cell-padding: 5px;'>
+<tr>${ths}</tr>
+${trs.join('\n')}
+</table>
+
+</code></pre>
+</body>
+
+<!-- Clickable column headings. -->
+<script>
+// Copy of
+// https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
+// Hackish, works.
+
+const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
+
+const comparer = (idx, asc) => (a, b) => ((v1, v2) =>
+    v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2)
+    )(getCellValue(asc ? a : b, idx), getCellValue(asc ? b : a, idx));
+
+// do the work...
+document.querySelectorAll('th').forEach(th => th.addEventListener('click', (() => {
+    const table = th.closest('table');
+    Array.from(table.querySelectorAll('tr:nth-child(n+2)'))
+        .sort(comparer(Array.from(th.parentNode.children).indexOf(th), this.asc = !this.asc))
+        .forEach(tr => table.appendChild(tr) );
+})));
+</script>
+
+</html>`
+
 
   return {
-    json: statuses,
+    statusCode: 200,
+    body: response_body,
     headers: {
+      'Content-Type': 'text/html',
       'cache-control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0'
     }
   }

--- a/src/http/get-status/index.js
+++ b/src/http/get-status/index.js
@@ -1,13 +1,10 @@
 const arc = require('@architect/functions')
 
-/**
- * Returns an array of statuses currently in the system
- */
-// TODO status monitoring
-// Ref https://github.com/covidatlas/li/issues/234
-// Should provide the source data for a simple page
-// | source | status (up || down) | last successful crawl | last successful scrape | error message (if status = down) |
-async function getStatus () {
+
+/** For each source, get scrape and crawl status, and last successful
+ * datetime. */
+async function statusSummaryJson () {
+
   const data = await arc.tables()
 
   // Running log
@@ -53,6 +50,16 @@ async function getStatus () {
       status
     }
   })
+
+  return summary
+}
+
+/**
+ * Returns an array of statuses currently in the system, or html if ?format=html
+ */
+async function getStatus (request) {
+
+  const summary = await statusSummaryJson()
 
   // TODO (status) generate HTML using some kind of templating engine.
   // Hacking to get HTML output for now, to be replaced w/ whatever

--- a/src/http/get-status/package-lock.json
+++ b/src/http/get-status/package-lock.json
@@ -1,0 +1,121 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@architect/functions": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.8.4.tgz",
+      "integrity": "sha512-tA+MX7yO1XD+IJwNZ80Ofu+U5DO4+BtXuYTyNPOWHQLySksLWALWv02Rl9sqwZvVLLXbW3Wqe4zjESvBHkU/ig==",
+      "requires": {
+        "aws-serverless-express": "^3.3.6",
+        "cookie": "^0.4.0",
+        "cookie-signature": "^1.1.0",
+        "csrf": "^3.1.0",
+        "mime-types": "^2.1.26",
+        "node-webtokens": "^1.0.4",
+        "run-parallel": "^1.1.9",
+        "run-waterfall": "^1.1.6",
+        "uid-safe": "^2.1.5"
+      }
+    },
+    "aws-serverless-express": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/aws-serverless-express/-/aws-serverless-express-3.3.8.tgz",
+      "integrity": "sha512-2TQdF5EhxnAtGeEi+wSi2M3xCfpiemuImnpU7HKih3onH0izJ/G2tkM+gwcGHZEsW/gLWFl/JjQAYGa3fILfvw==",
+      "requires": {
+        "binary-case": "^1.0.0",
+        "type-is": "^1.6.16"
+      }
+    },
+    "binary-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/binary-case/-/binary-case-1.1.4.tgz",
+      "integrity": "sha512-9Kq8m6NZTAgy05Ryuh7U3Qc4/ujLQU1AZ5vMw4cr3igTdi5itZC6kCNrRr2X8NzPiDn2oUIFTfa71DKMnue/Zg=="
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-signature": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz",
+      "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
+    },
+    "csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "node-webtokens": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-webtokens/-/node-webtokens-1.0.4.tgz",
+      "integrity": "sha512-Sla56CeSLWvPbwud2kogqf5edQtKNXZBtXDDpmOzAgNZjwETbK/Am6PXfs54iZPLBm8K8amZ9XWaCQwGqZmKyQ=="
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+    },
+    "run-waterfall": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
+      "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    }
+  }
+}

--- a/src/http/get-status/package.json
+++ b/src/http/get-status/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@architect/functions": "^3.8.4"
+  }
+}


### PR DESCRIPTION
# Summary

Adds `http://localhost:3333/status` to dump out simple status information from DynamoDB in an HTML table.  By default it dumps json, but can also dump html.

## json

http://localhost:3333/status

```
[
  {
    "source": "us-al",
    "crawler_status": "success",
    "crawler_consecutive": 1,
    "crawler_last_success": "2020-06-18 16:47:48",
    "scraper_status": "success",
    "scraper_consecutive": 1,
    "scraper_last_success": "2020-06-18 16:48:07",
    "status": "success"
  },
...
]
```

## html version

http://localhost:3333/status?format=html

![image](https://user-images.githubusercontent.com/1637133/85051922-22fce100-b166-11ea-871e-99856ecc6b9b.png)

Column heads are clickable for sorting.  I created the HTML view because it was quick(ish) and we really need it!  

# index.html

localhost:3333 shows some links now, fyi

![image](https://user-images.githubusercontent.com/1637133/85054926-c819b880-b16a-11ea-9f62-673220e03325.png)


# Future work

* There are a handful of TODO comments in the code for query efficiency
* We should add error details to the page (error message, and possibly stack traces)