### PR TITLE
Handle UNASSIGNED for locations and annotions.

### DIFF
--- a/src/events/locations/annotate/index.js
+++ b/src/events/locations/annotate/index.js
@@ -16,6 +16,17 @@ module.exports = function annotateLocations (locations) {
     }
 
     for (const bit of bits) {
+
+      // Some locations have UNASSIGNED for the case data location
+      // (i.e. unassigned state, or unassigned county).  In this case,
+      // skip the different cases handled below.  This will mean that
+      // the UNASSIGNED data will be given the same annotation as the
+      // next-higher level: UNASSIGNED state data will get
+      // country-level annotations, and UNASSIGNED county data will
+      // get state-level annotations.
+      if (!bit.includes(':'))
+        continue
+
       const p = bit.split(':')
       const level = p[0]
       const id = p[1].toUpperCase()


### PR DESCRIPTION
Addresses https://github.com/covidatlas/li/issues/248

(Running tests now; if they pass, I'll merge.)

With this change, unassigned locations get created correctly:

```
# log during scrape:
Creating new location: unassigned-georgia-us / iso1:us#iso2:us-ga#(unassigned)
```

Unassigned is listed in http://localhost:3333/locations:

```
.... "walker-county-georgia-us","unassigned-georgia-us","hart-county-georgia-us" ...
```

and case data is at http://localhost:3333/locations/unassigned-georgia-us:

```
[{"cases":1958,"date":"2020-06-21","deaths":1,"updated":"2020-06-21T22:49:02.692Z"}]
```

Its information is recorded in the 'locations' dynamoDB table as

```
{
  "locationID":"iso1:us#iso2:us-ga#(unassigned)",
  "slug":"unassigned-georgia-us",
  "name":"Unassigned cases, Georgia, US",
  "area":{"squareMeters":152698202463},
  "coordinates":[-83.45,32.65],
  "countryID":"iso1:US",
  "countryName":"United States",
  "population":10617423,
  "tz":"America/New_York",
  "level":"state",
  "stateID":"iso2:US-GA",
  "stateName":"Georgia",
  "created":"2020-06-21T22:49:08.780Z"
}
```