### PR TITLE
Remove unnecessary dependency.

### DIFF
--- a/src/events/scraper/run-scraper/scraper-helpers/normalize-key.js
+++ b/src/events/scraper/run-scraper/scraper-helpers/normalize-key.js
@@ -1,4 +1,3 @@
-const is = require('is')
 const assert = require('assert')
 const slugify = require('slugify')
 const parse = require('@architect/shared/sources/_lib/parse.js')
@@ -59,8 +58,8 @@ function _allPropertiesForHeading (heading, mapping) {
 
   const matchesHeading = m => {
     return false ||
-      (is.string(m) && slugged(heading).includes(slugged(m))) ||
-      (is.regexp(m) && heading.match(m))
+      (typeof(m) === 'string' && slugged(heading).includes(slugged(m))) ||
+      (m instanceof RegExp && heading.match(m))
   }
 
   return Object.keys(mapping).filter(prop => {


### PR DESCRIPTION
Use regular code, not libraries, for simple things.