### PR TITLE
Allow setting specific date in scraped records.

### DIFF
--- a/src/events/scraper/normalize-data/index.js
+++ b/src/events/scraper/normalize-data/index.js
@@ -35,6 +35,10 @@ module.exports = function normalizeData (source, output, date) {
       id += `#${location.county}`
     }
 
+    // Fill in the date if it's not already specified.
+    if (!location.date)
+      location.date = date
+
     // Normalize
     const locationID = id.toLowerCase()
 
@@ -42,7 +46,6 @@ module.exports = function normalizeData (source, output, date) {
     return Object.assign(location, {
       locationID,
       dateSource: `${date}#${_sourceKey}`,
-      date,
       source: _sourceKey,
       priority: source.priority || 0 // Backfill to 0 for sorting later
     })

--- a/tests/integration/events/scraper/index-test.js
+++ b/tests/integration/events/scraper/index-test.js
@@ -102,7 +102,7 @@ test('scrape writes to dynamodb', async t => {
 })
 
 
-test.only('can specify the date in the scraped record', async t => {
+test('can specify the date in the scraped record', async t => {
   await utils.setup()
 
   const hardcodedDate = '2020-01-23'

--- a/tests/integration/events/scraper/index-test.js
+++ b/tests/integration/events/scraper/index-test.js
@@ -102,6 +102,31 @@ test('scrape writes to dynamodb', async t => {
 })
 
 
+test.only('can specify the date in the scraped record', async t => {
+  await utils.setup()
+
+  const hardcodedDate = '2020-01-23'
+  const caseData = { cases: 10, deaths: 20, tested: 30, hospitalized: 40, icu: 50, date: hardcodedDate }
+  utils.writeFakeSourceContent('json-source/data.json', caseData)
+
+  const recs = await utils.crawl('json-source').
+        then(() => utils.scrape('json-source')).
+        then(() => arc.tables()).
+        then(tbls => tbls['case-data'].scan({})).
+        then(recs => recs.Items)
+  t.equal(recs.length, 1, '1 record only')
+
+  t.equal(recs[0].date, hardcodedDate, 'date hard-coded to 2020-01-23')
+
+  const actualDateSourceDate = recs[0].dateSource.split('#')[0]
+  t.ok(actualDateSourceDate !== hardcodedDate, `${actualDateSourceDate} <> ${hardcodedDate}`)
+  t.match(actualDateSourceDate, /\d{4}-\d{2}-\d{2}/)
+
+  await utils.teardown()
+  t.end()
+})
+
+
 test('cached file does not have to be compressed when working locally', async t => {
   await utils.setup()
 

--- a/tests/integration/fake-sources/sources/json-source.js
+++ b/tests/integration/fake-sources/sources/json-source.js
@@ -18,7 +18,7 @@ module.exports = {
         }
       ],
       scrape (json) {
-        return {
+        const record = {
           // TODO (testing) Add any fields that we need to check.
           cases: json.cases,
           deaths: json.deaths,
@@ -26,6 +26,9 @@ module.exports = {
           hospitalized: json.hospitalized,
           icu: json.icu
         }
+        if (json.date)
+          record.date = json.date
+        return record
       }
     }
   ]


### PR DESCRIPTION
## Summary

This PR proposes allowing scrapers to set the date in the returned record, eg.: `{ cases: 10, date: '2020-01-23' }`, as opposed to just returning the record `{ cases: 10 }`, and having the date get assigned.

## Why this is necessary.

* deterministic testing
* in future, we may want scrapers to submit data for multiple dates.

## Code notes

The only change is in `_normalize-data`.  The rest is a quick verification.