### PR TITLE
Batch csv writes

### DIFF
--- a/src/events/reports/generate-data/_build-base-json.js
+++ b/src/events/reports/generate-data/_build-base-json.js
@@ -25,6 +25,13 @@ function addPopulationDensity (rec) {
   }
 }
 
+function addLatLong (rec) {
+  if (rec.coordinates) {
+    rec.lat = rec.coordinates[1]
+    rec['long'] = rec.coordinates[0]
+  }
+}
+
 /** Given array of hashes, gets unique elements, where uniquness is
  * determined by key value. */
 function uniqueByKey (arr, key) {
@@ -53,6 +60,7 @@ async function getBaseJson (params, statusCallback = baseJsonStatus) {
     statusCallback(i, locations.length)
     const loc = locations[i]
     addPopulationDensity(loc)
+    addLatLong(loc)
     const ts = await getTimeseriesForLocation(data, loc.locationID)
     const sources = ts.sources.map(s => getSource({ source: s, ...params }))
     const maintainers = uniqueByKey(sources.map(s => s.maintainers).flat(), 'name')

--- a/src/events/reports/write-reports/index.js
+++ b/src/events/reports/write-reports/index.js
@@ -14,7 +14,7 @@ function locations (baseJson, writableStream) {
   if (!baseJson) throw new Error('baseJson data is required')
   const content = baseJson.map(loc => {
     const rec = Object.assign({}, loc)
-    removeFields(rec, [ 'timeseries', 'timeseriesSources', 'warnings', 'area', 'created', 'updated' ])
+    removeFields(rec, [ 'timeseries', 'timeseriesSources', 'warnings', 'area', 'created', 'updated', 'lat', 'long' ])
     return rec
   })
   writableStream.write(JSON.stringify(content, null, 2))
@@ -25,7 +25,7 @@ function timeseriesByLocation (baseJson, writableStream) {
   if (!baseJson) throw new Error('baseJson data is required')
   const content = baseJson.map(loc => {
     const rec = Object.assign({}, loc)
-    removeFields(rec, [ 'area', 'created', 'updated' ])
+    removeFields(rec, [ 'area', 'created', 'updated', 'lat', 'long' ])
     return rec
   })
   writableStream.write(JSON.stringify(content, null, 2))
@@ -50,17 +50,6 @@ const baseCsvColumns = [
 ].map(s => { return { key: s, header: s.replace('Name', '') } })
 
 
-function baseCsv (baseJson) {
-  if (!baseJson) throw new Error('baseJson data is required')
-  return baseJson.map(loc => {
-    let rec = Object.assign({}, loc)
-    rec.lat = rec.coordinates[1]
-    rec['long'] = rec.coordinates[0]
-    return rec
-  })
-}
-
-
 /** timeseries.csv source.
  *
  */
@@ -73,7 +62,7 @@ function timeseries (baseJson, writeableStream) {
   writeableStream.write(stringify([ headings ]))
 
   const columns = cols.map(c => c.key)
-  baseCsv(baseJson).forEach(rec => {
+  baseJson.forEach(rec => {
     Object.keys(rec.timeseries).forEach(dt => {
       const outrec = {
         ...rec,
@@ -103,7 +92,7 @@ function timeseriesJhu (baseJson, writeableStream) {
   writeableStream.write(stringify([ headings ]))
 
   const columns = cols.map(c => c.key)
-  baseCsv(baseJson).forEach(rec => {
+  baseJson.forEach(rec => {
     const cases = Object.entries(rec.timeseries).
       reduce((hsh, e) => Object.assign(hsh, { [e[0]]: e[1].cases }), {})
     const outrec = Object.assign(rec, cases)
@@ -159,7 +148,7 @@ async function timeseriesTidy (baseJson, writeableStream) {
   const recCount = baseJson.length
 
   const columns = cols.map(c => c.key)
-  baseCsv(baseJson).forEach((rec, index) => {
+  baseJson.forEach((rec, index) => {
 
     if (index % 50 === 0)
       console.log(`writing timeseriesTidy, record ${index + 1} of ${recCount}`)


### PR DESCRIPTION
Write CSV records in batches, instead of one-by-one.

The current impl is silly -- it's writing to s3 for every single csv record, which will result in multiple thousands of writes