### PR TITLE
Issue 279: allow single crawl to have a name.

### DIFF
--- a/src/events/crawler/_crawl.js
+++ b/src/events/crawler/_crawl.js
@@ -31,7 +31,7 @@ module.exports = async function crawl (event) {
     for (let crawl of scraper.crawl) {
       let { type, url, paginated } = crawl
 
-      const _name = scraper.crawl.length > 1 ? crawl.name : 'default'
+      const _name = crawl.name || 'default'
       const baseResult = {
         // Caching metadata
         _sourceKey,

--- a/src/events/scraper/run-scraper/index.js
+++ b/src/events/scraper/run-scraper/index.js
@@ -27,7 +27,7 @@ const scraperHelpers = {
 module.exports = async function runScraper (scraper, parsed, date) {
   let params = {}
   // A single crawl passes back a single object
-  if (parsed.length === 1) params = parsed[0]['default']
+  if (parsed.length === 1) params = Object.values(parsed[0])[0]
   // Multiple crawls pass back an object with a named param for each `crawl.name`
   else {
     for (const item of parsed) {

--- a/src/shared/sources/_lib/validate-source.js
+++ b/src/shared/sources/_lib/validate-source.js
@@ -105,14 +105,12 @@ function validateSource (source) {
       }
 
       // Crawl name keys
-      if (crawl.length === 1) {
-        requirement(!crawler.name, datedError('Single crawler must not have a name key'))
-      }
-      else {
-        requirement(crawler.name, 'Multiple crawlers must have a name')
+      if (crawl.length > 1) {
+        requirement(crawler.name, datedError('Multiple crawlers must have a name'))
         requirement(crawler.name !== 'default', datedError(`Crawler name cannot be 'default'`))
         requirement(/^[a-z]+$/.test(crawler.name), datedError(`Crawler name must be lowercase letters only`))
-        requirement(crawler.name.length <= 20, datedError(`Crawler name must be 20 chars or less`))
+        if (crawler.name)
+          requirement(crawler.name.length <= 20, datedError(`Crawler name must be 20 chars or less`))
         requirement(
           !crawlerNames[crawler.name], datedError(`Duplicate crawler name '${crawler.name}'; names must be unique`)
         )

--- a/tests/integration/events/scraper/single-crawl-with-name-test.js
+++ b/tests/integration/events/scraper/single-crawl-with-name-test.js
@@ -1,0 +1,43 @@
+process.env.NODE_ENV = 'testing'
+
+const test = require('tape')
+const utils = require('../../_lib/utils.js')
+const path = require('path')
+const testCache = utils.testCache
+
+
+test('scrape gets data from named parameter', async t => {
+  await utils.setup()
+
+  const caseData = { count: 10 }
+  utils.writeFakeSourceContent('single-crawl-with-name/data.json', caseData)
+  await utils.crawl('single-crawl-with-name')
+  t.equal(1, testCache.allFiles().length, 'sanity check.')
+  const cacheFileName = testCache.allFiles()[0].split(path.sep).slice(-1)[0]
+  t.match(cacheFileName, /-cases-/, 'filename should contain cases')
+
+  const fullResult = await utils.scrape('single-crawl-with-name')
+  const result = fullResult[0]
+  t.ok(result, 'Have result')
+
+  const actual = result.data
+  t.ok(actual, 'Have data')
+  t.equal(1, actual.length, '1 record in returned data')
+
+  // These fields should match exactly.
+  const expected = {
+    country: 'iso1:US',
+    state: 'iso2:US-CA',
+    county: 'fips:06007',
+    locationID: 'iso1:us#iso2:us-ca#fips:06007',
+    source: 'single-crawl-with-name',
+    cases: 10,
+    priority: 1
+  }
+  Object.keys(expected).forEach(key => {
+    t.equal(expected[key], actual[0][key], key)
+  })
+
+  await utils.teardown()
+  t.end()
+})

--- a/tests/integration/fake-sources/sources/single-crawl-with-name.js
+++ b/tests/integration/fake-sources/sources/single-crawl-with-name.js
@@ -1,0 +1,27 @@
+module.exports = {
+  country: 'iso1:US',
+  state: 'CA',
+  county: 'fips:06007',
+  maintainers: [ { name: 'John Smith', github: 'jsmith42' } ],
+  priority: 1,
+  friendly: {
+    name: 'Canadian COVID Rolling Task Force',
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  },
+  scrapers: [
+    {
+      startDate: '2020-03-01',
+      crawl: [
+        {
+          name: 'cases',
+          type: 'json',
+          url: 'http://localhost:5555/tests/fake-source-urls/single-crawl-with-name/data.json'
+        }
+      ],
+      scrape (cases) {
+        const result = { cases: cases.count }
+        return [ result ]
+      }
+    }
+  ]
+}

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -71,6 +71,14 @@ test('validateSource catches problems', t => {
           { name: 'cases' /* dup. name */, type: 'page', url: 'https://somedata.html' }
         ],
         scrape (data) { return { cases: 42 + data.count } }
+      },
+      {
+        startDate: '2020-03-04',
+        crawl: [
+          { /* must have a name */ type: 'csv', data: 'table', url: 'https://somedata.csv' },
+          { name: 'cases', type: 'page', url: 'https://somedata.html' }
+        ],
+        scrape (data) { return { cases: 42 + data.count } }
       }
     ]
   }
@@ -93,11 +101,43 @@ test('validateSource catches problems', t => {
     '2020-03-01: Invalid crawler.type \'text\'; must be one of: page, headless, csv, tsv, pdf, json, raw',
     '2020-03-01: Crawler must have either url or paginated, but not both',
     '2020-03-01: Crawler paginated must be an async function',
+    '2020-03-04: Multiple crawlers must have a name',
     'Scraper must contain a startDate',
-    '2020-03-02: Single crawler must not have a name key',
-    '(missing startDate): Single crawler must not have a name key'
+    // '2020-03-02: Single crawler must not have a name key', // Not anymore.
+    // '(missing startDate): Single crawler must not have a name key'
   ]
   t.deepEqual(result.errors.sort(), expectedErrors.sort(), 'expected errors caught')
+})
+
+
+// Ref https://github.com/covidatlas/li/issues/279,
+// "Allow single crawl to have a name"
+test('single source crawl can have a name', t => {
+
+  const src = {
+    country: 'iso1:us',
+    state: 'iso2:ca',
+    scrapers: [
+      {
+        startDate: '2020-03-01',
+        crawl: [
+          {
+            name: 'data',
+            type: 'csv',
+            url: 'https://somedata.csv'
+          }
+        ],
+        scrape ( { data } ) { return { cases: data.cases } }
+      }
+    ]
+  }
+
+  const result = validateSource(src)
+
+  const expectedErrors = []
+  t.deepEqual(result.errors.sort(), expectedErrors.sort(), 'no errors')
+
+  t.end()
 })
 
 


### PR DESCRIPTION
Ref https://github.com/covidatlas/li/issues/279

Necessary for expedient fixes.