### PR TITLE
[patch] fix NG source

### DIFF
--- a/src/shared/sources/ng/index.js
+++ b/src/shared/sources/ng/index.js
@@ -5,7 +5,8 @@ const transform = require('../_lib/transform.js')
 const country = 'iso1:NG'
 
 const nameToCanonical = { // Name differences get mapped to the canonical names
-  'Nassarawa': 'Nasarawa'
+  'FCT': 'Federal Capital Territory',
+  'Nassarawa': 'Nasarawa',
 }
 
 module.exports = {


### PR DESCRIPTION
Was missing a mapping, they're using an abbreviation for Federal Capital Territory as FCT