### PR TITLE
Fix regeneration for timeseries.

### DIFF
--- a/.arc
+++ b/.arc
@@ -30,7 +30,7 @@ status      # Status updater
 
 @scheduled
 runner rate(2 hours)            # Regularly invokes crawls and scrapes
-regen-timeseries rate(2 hours)  # Regularly regenerates timeseries sources
+regen-timeseries rate(15 minutes)  # Regularly regenerates timeseries sources
 gen-reports rate(2 hours)       # Fire event to regenerate reports
 
 

--- a/src/events/regenerator/fire-events/_get-date-range.js
+++ b/src/events/regenerator/fire-events/_get-date-range.js
@@ -1,0 +1,19 @@
+const datetime = require('@architect/shared/datetime/index.js')
+
+/** Gets an array of dates, with the earliest and the latest as the
+ * boundaries.
+ *
+ * Such a simple function, but js can make it difficult.
+ */
+module.exports = function getDatesRange (earliestYYYYMMDD, latestYYYYMMDD) {
+
+  const d = new Date(earliestYYYYMMDD)
+  const latest = new Date(latestYYYYMMDD)
+  let dates = []
+  while (d <= latest) {
+    d.setDate(d.getDate() + 1)
+    dates.push(datetime.getYYYYMMDD(d))
+  }
+  return dates
+
+}

--- a/src/events/regenerator/fire-events/_get-date-range.js
+++ b/src/events/regenerator/fire-events/_get-date-range.js
@@ -1,11 +1,26 @@
 const datetime = require('@architect/shared/datetime/index.js')
 
+
+function throwIfNonDate (d) {
+  if (!d)
+    throw new Error('null or undefined date')
+  const dateRe  = /\d{4}-\d{2}-\d{2}/
+  if (!d.match(dateRe))
+    throw new Error(`date '${d}', does not match regex ${dateRe}`)
+}
+
 /** Gets an array of dates, with the earliest and the latest as the
  * boundaries.
  *
  * Such a simple function, but js can make it difficult.
  */
 module.exports = function getDatesRange (earliestYYYYMMDD, latestYYYYMMDD) {
+
+  throwIfNonDate(earliestYYYYMMDD)
+  throwIfNonDate(latestYYYYMMDD)
+
+  if (earliestYYYYMMDD > latestYYYYMMDD)
+    throw new Error(`${earliestYYYYMMDD} > ${latestYYYYMMDD}`)
 
   const d = new Date(earliestYYYYMMDD)
   const latest = new Date(latestYYYYMMDD)
@@ -15,5 +30,4 @@ module.exports = function getDatesRange (earliestYYYYMMDD, latestYYYYMMDD) {
     dates.push(datetime.getYYYYMMDD(d))
   }
   return dates
-
 }

--- a/src/events/regenerator/fire-events/index.js
+++ b/src/events/regenerator/fire-events/index.js
@@ -32,7 +32,7 @@ module.exports = async function fireEvents (source) {
           }
         })
       }, queue)
-      queue += 1000
+      queue += 200
     })
   })
 

--- a/src/events/regenerator/fire-events/index.js
+++ b/src/events/regenerator/fire-events/index.js
@@ -1,6 +1,7 @@
 const arc = require('@architect/functions')
 const sorter = require('@architect/shared/utils/sorter.js')
 const datetime = require('@architect/shared/datetime/index.js')
+const getDatesRange = require('./_get-date-range.js')
 
 module.exports = async function fireEvents (source) {
   const { scrapers } = source
@@ -10,12 +11,7 @@ module.exports = async function fireEvents (source) {
 
   // In the future perhaps we can do something smarter than starting from startDate
   const today = new Date()
-  const d = new Date(earliest)
-  let dates = []
-  while (d < today) {
-    d.setDate(d.getDate() + 1)
-    dates.push(datetime.getYYYYMMDD(d))
-  }
+  const dates = getDatesRange(earliest, datetime.getYYYYMMDD(today))
 
   // The return of el cheapo queue
   let queue = 0

--- a/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
+++ b/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
@@ -19,8 +19,8 @@ module.exports = function nextInvoke (invokes, nowISOString) {
   twelveHrsAgo = new Date(twelveHrsAgo).toISOString()
 
   const invokesByStaleness = invokes.
-        sort(byDateThenKey).
-        filter(i => (!i.lastInvoke || i.lastInvoke < twelveHrsAgo))
+        filter(i => (!i.lastInvoke || i.lastInvoke < twelveHrsAgo)).
+        sort(byDateThenKey)
 
   if (invokesByStaleness.length === 0)
     return null

--- a/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
+++ b/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
@@ -2,6 +2,14 @@
 
 module.exports = function nextInvoke (invokes) {
 
+  const dateKey = a => `${a.lastInvoke || '1970-01-01T00:00:00.000Z'}/${a.key}`
+  const byDateThenKey = (a, b) => dateKey(a) < dateKey(b) ? - 1 : 1
+
+  /* sort invokes by date, mapping null dates to very old date so they
+   * go to the top. */
+  const invokesByStaleness = invokes.sort(byDateThenKey)
+
+  /*
   const next = invokes.find(i => {
     // Never regenerate more than every 12 hours
     const meow = new Date()
@@ -9,6 +17,8 @@ module.exports = function nextInvoke (invokes) {
     aBitAgo = new Date(aBitAgo).toISOString()
     return !i.lastInvoke || aBitAgo > i.lastInvoke
   })
+  */
+  const next = invokesByStaleness[0]
 
   return next.key
 }

--- a/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
+++ b/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
@@ -1,24 +1,29 @@
-/** Find the next thing to invoke. */
+/** Find the next timeseries to invoke.
+ *
+ * Invoke things that have never been invoked before others that have.
+ * Invoke by most stale.
+ * Don't invoke recently invoked (< 12 hrs ago).
+ */
+module.exports = function nextInvoke (invokes, nowISOString) {
 
-module.exports = function nextInvoke (invokes) {
-
+  // sort invokes by date, mapping null dates to very old date so they
+  // go to the top.
   const dateKey = a => `${a.lastInvoke || '1970-01-01T00:00:00.000Z'}/${a.key}`
   const byDateThenKey = (a, b) => dateKey(a) < dateKey(b) ? - 1 : 1
 
-  /* sort invokes by date, mapping null dates to very old date so they
-   * go to the top. */
-  const invokesByStaleness = invokes.sort(byDateThenKey)
+  // Do not invoke anything if it's less than 12 hours old.
+  let now = new Date()
+  if (nowISOString)
+    now = new Date(nowISOString)
+  let twelveHrsAgo = now.setHours(now.getHours() - 12)
+  twelveHrsAgo = new Date(twelveHrsAgo).toISOString()
 
-  /*
-  const next = invokes.find(i => {
-    // Never regenerate more than every 12 hours
-    const meow = new Date()
-    let aBitAgo = meow.setHours(meow.getHours() - 12)
-    aBitAgo = new Date(aBitAgo).toISOString()
-    return !i.lastInvoke || aBitAgo > i.lastInvoke
-  })
-  */
-  const next = invokesByStaleness[0]
+  const invokesByStaleness = invokes.
+        sort(byDateThenKey).
+        filter(i => (!i.lastInvoke || i.lastInvoke < twelveHrsAgo))
 
-  return next.key
+  if (invokesByStaleness.length === 0)
+    return null
+
+  return invokesByStaleness[0].key
 }

--- a/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
+++ b/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
@@ -1,0 +1,6 @@
+/** Find the next thing to invoke. */
+
+module.exports = function nextInvoke (invokes) {
+
+  return invokes[0].key
+}

--- a/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
+++ b/src/scheduled/regen-timeseries/find-invoke/_next-invoke.js
@@ -2,5 +2,13 @@
 
 module.exports = function nextInvoke (invokes) {
 
-  return invokes[0].key
+  const next = invokes.find(i => {
+    // Never regenerate more than every 12 hours
+    const meow = new Date()
+    let aBitAgo = meow.setHours(meow.getHours() - 12)
+    aBitAgo = new Date(aBitAgo).toISOString()
+    return !i.lastInvoke || aBitAgo > i.lastInvoke
+  })
+
+  return next.key
 }

--- a/tests/unit/events/regenerator/fire-events/_get-date-range-test.js
+++ b/tests/unit/events/regenerator/fire-events/_get-date-range-test.js
@@ -11,6 +11,14 @@ test('can get range', t => {
 })
 
 
+test('same start and end', t => {
+  const actual = getDatesRange('2020-07-11', '2020-07-11')
+  const expected = [ '2020-07-11' ]
+  t.deepEqual(expected, actual)
+  t.end()
+})
+
+
 test('works for daylight savings', t => {
   const actual = getDatesRange('2020-03-06', '2020-03-12')
   const expected = []
@@ -19,10 +27,69 @@ test('works for daylight savings', t => {
   t.end()
 })
 
-// daylight savings
-// month turnover
-// year turnover
-// leap year
-// throws if bad dates
-// throws if non-dates
-// throws if null
+
+test('works at month turnover', t => {
+  const actual = getDatesRange('2020-03-29', '2020-04-02')
+  const expected = [
+    '2020-03-29',
+    '2020-03-30',
+    '2020-03-31',
+    '2020-04-01',
+    '2020-04-02'
+  ]
+  t.deepEqual(expected, actual)
+  t.end()
+})
+
+
+test('works at year turnover', t => {
+  const actual = getDatesRange('2020-12-30', '2021-01-02')
+  const expected = [
+    '2020-12-30',
+    '2020-12-31',
+    '2021-01-01',
+    '2021-01-02'
+  ]
+  t.deepEqual(expected, actual)
+  t.end()
+})
+
+
+test('works at leap year', t => {
+  let actual = getDatesRange('2020-02-27', '2020-03-01')
+  let expected = [
+    '2020-02-27',
+    '2020-02-28',
+    '2020-02-29',
+    '2020-03-01'
+  ]
+  t.deepEqual(expected, actual, 'leap year')
+
+  actual = getDatesRange('2021-02-27', '2021-03-01')
+  expected = [
+    '2021-02-27',
+    '2021-02-28',
+    '2021-03-01'
+  ]
+  t.deepEqual(expected, actual, 'non-leap year')
+
+  t.end()
+})
+
+
+test('throws on non dates', t => {
+  t.throws(() => getDatesRange('something', 'here'))
+  t.end()
+})
+
+
+test('throws if earlier > later', t => {
+  t.throws(() => getDatesRange('2020-07-08', '2020-07-07'))
+  t.end()
+})
+
+
+test('throws if missing date', t => {
+  t.throws(() => getDatesRange(null, '2020-07-11'))
+  t.end()
+})

--- a/tests/unit/events/regenerator/fire-events/_get-date-range-test.js
+++ b/tests/unit/events/regenerator/fire-events/_get-date-range-test.js
@@ -1,0 +1,28 @@
+const getDatesRange = require('../../../../../src/events/regenerator/fire-events/_get-date-range.js')
+const test = require('tape')
+
+
+test('can get range', t => {
+  const actual = getDatesRange('2020-07-11', '2020-07-15')
+  const expected = []
+  for (let i = 11; i <= 15; i++) expected.push(`2020-07-${i}`)
+  t.deepEqual(expected, actual)
+  t.end()
+})
+
+
+test('works for daylight savings', t => {
+  const actual = getDatesRange('2020-03-06', '2020-03-12')
+  const expected = []
+  for (let i = 6; i <= 12; i++) expected.push(`2020-03-${('' + i).padStart(2, '0')}`)
+  t.deepEqual(expected, actual)
+  t.end()
+})
+
+// daylight savings
+// month turnover
+// year turnover
+// leap year
+// throws if bad dates
+// throws if non-dates
+// throws if null

--- a/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
+++ b/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
@@ -1,0 +1,17 @@
+const nextInvoke = require('../../../../../src/scheduled/regen-timeseries/find-invoke/_next-invoke.js')
+const test = require('tape')
+
+
+function getInvokes (arr) {
+  return arr.map(a => { return { key: a[0], lastInvoke: a[1] } })
+}
+
+test('if nothing has been invoked get the next by alphabet', t => {
+  const invokes = getInvokes([
+    [ 'a', null ],
+    [ 'b', null ]
+  ])
+
+  t.equal(nextInvoke(invokes), 'a', 'return first')
+  t.end()
+})

--- a/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
+++ b/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
@@ -39,7 +39,7 @@ test('gets first non-invoked by alpha even if invoked is very old', t => {
   t.end()
 })
 
-/*
+
 test('gets source that was invoked earliest', t => {
   const invokes = getInvokes([
     [ 'a', '1971-01-01T00:00:00.000Z' ],
@@ -76,4 +76,3 @@ test('returns null if execution was < 12 hours ago', t => {
   t.equal(nextInvoke(invokes, '2020-06-06T19:00:00.000Z'), null, '< 12 hrs')
   t.end()
 })
-*/

--- a/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
+++ b/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
@@ -15,3 +15,14 @@ test('if nothing has been invoked get the next by alphabet', t => {
   t.equal(nextInvoke(invokes), 'a', 'return first')
   t.end()
 })
+
+
+test('get first non-invoked by alphabet', t => {
+  const invokes = getInvokes([
+    [ 'a', new Date().toISOString() ],
+    [ 'b', null ]
+  ])
+
+  t.equal(nextInvoke(invokes), 'b', 'not invoked yet')
+  t.end()
+})

--- a/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
+++ b/tests/unit/scheduled/regen-timeseries/find-invoke/_next-invoke-test.js
@@ -6,6 +6,7 @@ function getInvokes (arr) {
   return arr.map(a => { return { key: a[0], lastInvoke: a[1] } })
 }
 
+
 test('if nothing has been invoked get the next by alphabet', t => {
   const invokes = getInvokes([
     [ 'a', null ],
@@ -17,7 +18,7 @@ test('if nothing has been invoked get the next by alphabet', t => {
 })
 
 
-test('get first non-invoked by alphabet', t => {
+test('gets first non-invoked by alphabet', t => {
   const invokes = getInvokes([
     [ 'a', new Date().toISOString() ],
     [ 'b', null ]
@@ -26,3 +27,53 @@ test('get first non-invoked by alphabet', t => {
   t.equal(nextInvoke(invokes), 'b', 'not invoked yet')
   t.end()
 })
+
+
+test('gets first non-invoked by alpha even if invoked is very old', t => {
+  const invokes = getInvokes([
+    [ 'a', '2020-01-01T00:00:00.000Z' ],
+    [ 'b', null ]
+  ])
+
+  t.equal(nextInvoke(invokes), 'b', 'not invoked yet')
+  t.end()
+})
+
+/*
+test('gets source that was invoked earliest', t => {
+  const invokes = getInvokes([
+    [ 'a', '1971-01-01T00:00:00.000Z' ],
+    [ 'b', '1970-01-01T00:00:00.000Z' ]
+  ])
+
+  t.equal(nextInvoke(invokes), 'b', 'b was invoked first, should go first')
+  t.end()
+})
+
+
+test('gets source invoked earliest by alpha', t => {
+  const invokes = getInvokes([
+    [ 'a', '1971-01-01T00:00:00.000Z' ],
+    [ 'd', '1970-01-01T00:00:00.000Z' ],
+    [ 'x', '1970-01-01T00:00:00.000Z' ]
+  ])
+
+  t.equal(nextInvoke(invokes), 'd', 'd goes before x')
+  t.end()
+})
+
+
+test('returns null if execution was < 12 hours ago', t => {
+  const invokes = getInvokes([
+    // 9 am
+    [ 'a', '2020-06-06T09:00:00.000Z' ],
+    // 8 am
+    [ 'd', '2020-06-06T08:00:00.000Z' ],
+  ])
+
+  t.equal(nextInvoke(invokes), 'd', 'd is oldest')
+  t.equal(nextInvoke(invokes, '2020-06-06T21:00:00.000Z'), 'd', 'd oldest')
+  t.equal(nextInvoke(invokes, '2020-06-06T19:00:00.000Z'), null, '< 12 hrs')
+  t.end()
+})
+*/


### PR DESCRIPTION
Fix regeneration.  Old code was calling `const next = invokes.find(i => {`, finding the first timeseries that met the criteria ... but it actually needed to consider all timeseries and pick the best one, not just the first one.  Test cases confirmed this.  I don't have an integration test but this should work.