### PR TITLE
Fix merc date.

### DIFF
--- a/src/shared/sources/us/ca/mercury-news.js
+++ b/src/shared/sources/us/ca/mercury-news.js
@@ -65,7 +65,7 @@ module.exports = {
           throw new Error(`Timeseries does not contain a sample for ${filterDate}`)
         }
 
-        counties.push(transform.sumData(counties))
+        counties.push({ ...transform.sumData(counties), date: filterDate })
         return counties
       }
     }


### PR DESCRIPTION
Fixes the date of the final rollup record:

```
│   56    │ 'iso1:us#iso2:us-ca#fips:06113' │ '2020-07-29' │  1447  │   41   │           │  23709  │     123      │                      │             │     │
│   57    │ 'iso1:us#iso2:us-ca#fips:06115' │ '2020-07-29' │  441   │   4    │    196    │  4361   │      42      │          6           │      0      │     │
│   58    │      'iso1:us#iso2:us-ca'       │ '2020-07-29' │ 485300 │  8901  │  117835   │ 5257026 │     4048     │         5792         │     848     │ 632 │
└─────────┴─────────────────────────────────┴──────────────┴────────┴────────┴───────────┴─────────┴──────────────┴──────────────────────┴─────────────┴─────┘
```