### PR TITLE
Fix Mercury News parser for large counties

### DIFF
--- a/src/shared/sources/us/ca/mercury-news.js
+++ b/src/shared/sources/us/ca/mercury-news.js
@@ -55,7 +55,7 @@ module.exports = {
           }
           for (const [ k, f ] of Object.entries(propToField)) {
             if (row[f] !== '')
-              record[k] = parseInt(row[f], 10)
+              record[k] = parseInt(row[f].replace(/,/g, ''), 10)
           }
           return record
         })


### PR DESCRIPTION
The _Mercury News_ spreadsheet is hand-entered; sometimes it comes with digit grouping characters, which ended up truncating the numbers in the scraper. This change removes the grouping characters, restoring the full numbers. Unfortunately, this spreadsheet only tracks current numbers, and change tracking doesn’t seem to be enabled. A number of incorrect days will need to be removed or replaced by hand by looking at county dashboards. This will result in inconsistencies, because the _Mercury News_ was tracking only the latest reported figures, not adjusting the numbers as the counties have been retroactively updating old numbers.

Fixes #370.

/ref https://github.com/covidatlas/li/issues/363#issuecomment-668190268