### PR TITLE
Santa Clara County, California

### DIFF
--- a/docs/sample-sources/sample.js
+++ b/docs/sample-sources/sample.js
@@ -12,7 +12,7 @@ module.exports = {
 
   /** The location this source covers. */
   country: 'iso1:US',
-  state: 'iso2:CA',
+  state: 'iso2:US-CA',
 
   /** Who contributed the source crawl and scrape.  This is included
    * in generated reports.  Array of objects with `{ name, url,

--- a/src/shared/sources/us/ca/santa-clara-county.js
+++ b/src/shared/sources/us/ca/santa-clara-county.js
@@ -1,0 +1,96 @@
+const maintainers = require('../../_lib/maintainers.js')
+
+module.exports = {
+  country: 'iso1:US',
+  state: 'iso2:US-CA',
+  county: 'fips:06085',
+
+  maintainers: [ maintainers.mnguyen ],
+
+  timeseries: true,
+  priority: 1,
+  friendly: {
+    name: 'County of Santa Clara Open Data Portal',
+    url: 'https://data.sccgov.org/browse?category=COVID-19'
+  },
+
+  scrapers: [
+    {
+      startDate: '2020-01-27',
+      crawl: [
+        {
+          type: 'json',
+          name: 'casedata',
+          url: 'https://data.sccgov.org/resource/6cnm-gchg.json',
+        },
+        {
+          type: 'json',
+          name: 'deathdata',
+          url: 'https://data.sccgov.org/resource/tg4j-23y2.json',
+        },
+        {
+          type: 'json',
+          name: 'patientdata',
+          url: 'https://data.sccgov.org/resource/5xkz-6esm.json',
+        },
+        {
+          type: 'json',
+          name: 'testdata',
+          url: 'https://data.sccgov.org/resource/dvgc-tzgq.json',
+        },
+      ],
+      scrape ({ casedata, deathdata, patientdata, testdata }, date) {
+        var result = {}
+        const dateTime = date + 'T00:00:00.000'
+
+        const filteredCaseData = casedata.filter(r => r.date === dateTime)
+        // Don't throw just because there's no case data; testing and hospitalization data may be fresher.
+        if (filteredCaseData.length !== 0 && filteredCaseData[0].total_cases) {
+          result.cases = parseInt(filteredCaseData[0].total_cases, 10)
+        }
+
+        // Death dataset only includes records for days on which there are new deaths, so there may be gaps.
+        // Take the latest day up to the requested day or the last day on which cases or deaths are available.
+        // If the most recent few days have case data but no death data, it likely means no recent deaths.
+        const filteredDeathData = deathdata.filter(r => r.date <= dateTime).slice(-1)
+        if (filteredDeathData.length !== 0 &&
+            (dateTime <= deathdata.slice(-1)[0].date || dateTime <= casedata.slice(-1)[0].date) &&
+            filteredDeathData[0].cumulative) {
+          result.deaths = parseInt(filteredDeathData[0].cumulative, 10)
+        }
+
+        const filteredPatientData = patientdata.filter(r => r.date === dateTime)
+        if (filteredPatientData.length !== 0) {
+          const confirmedPatients = filteredPatientData[0].covid_total &&
+            parseInt(filteredPatientData[0].covid_total, 10)
+          const pui = filteredPatientData[0].pui_total && parseInt(filteredPatientData[0].pui_total, 10)
+          if (confirmedPatients || pui) {
+            result.hospitalized_current = confirmedPatients + pui
+          }
+          const confirmedICU = filteredPatientData[0].icu_covid && parseInt(filteredPatientData[0].icu_covid, 10)
+          const puiICU = filteredPatientData[0].icu_pui && parseInt(filteredPatientData[0].icu_pui, 10)
+          if (confirmedICU || puiICU) {
+            result.icu_current = confirmedICU + puiICU
+          }
+        }
+
+        // Test dataset only includes records for days on which there are new tests, so there may be gaps.
+        // Take the latest day up to the requested day or the last day on which tests are available.
+        // If the most recent few days have case data but no test data, it probably means a delay in reporting tests.
+        const filteredTestData = testdata.filter(r => r.collection_date <= dateTime).slice(-1)
+        if (filteredTestData.length !== 0 &&
+            dateTime <= testdata.slice(-1)[0].collection_date &&
+            filteredTestData[0].total) {
+          result.tested = parseInt(filteredTestData[0].total, 10)
+        }
+
+        if (Object.keys(result).length === 0) {
+          throw new Error(`No data as at ${date}`)
+        }
+
+        return result
+      }
+    },
+  ]
+
+}


### PR DESCRIPTION
Added a source for Santa Clara County, California, that uses the following datasets from the county public health department via the county’s open data portal:

* [COVID-19 case counts by date](https://data.sccgov.org/COVID-19/COVID-19-case-counts-by-date/6cnm-gchg)
* [COVID-19 hospitalizations by date](https://data.sccgov.org/COVID-19/COVID-19-hospitalizations-by-date/5xkz-6esm)
* [Count of deaths with COVID-19 by date](https://data.sccgov.org/COVID-19/Count-of-deaths-with-COVID-19-by-date/tg4j-23y2)
* [COVID-19 testing by date](https://data.sccgov.org/COVID-19/COVID-19-testing-by-date/dvgc-tzgq)

The case count dataset lags a few days behind the public health department’s [Power BI dashboard](https://www.sccgov.org/sites/covid19/Pages/dashboard-cases.aspx). Not only is it missing the latest few days, which the dashboard deemphasizes as being preliminary, but it also doesn’t reflect the latest revisions to scores of past dates. For example, this scraper reports 9,655 cases on July 25. That was what the county attributed to July 25 [as of July 31](https://commons.wikimedia.org/wiki/Special:Diff/436353310), but the number has since been revised upward to 10,044. Still, it’s more accurate than the 8,833 that the _Mercury News_ scraper comes up with, based on what the county reported for July 25 as of July 25.

covidatlas/coronadatascraper#1026 scraped the dashboard but was more fragile for that reason. Perhaps we could offer both the open data portal and the Power BI dashboard as complementary datasets: one more up-to-date, the other more durable.

This PR also contains a small correction to the sample source.