### PR TITLE
Marin County, California

### DIFF
--- a/src/shared/sources/us/ca/marin-county.js
+++ b/src/shared/sources/us/ca/marin-county.js
@@ -10,7 +10,7 @@ module.exports = {
   maintainers: [ maintainers.mnguyen ],
 
   timeseries: true,
-  priority: 1,
+  priority: 2,
   friendly: {
     name: 'Marin Health & Human Services',
     url: 'https://coronavirus.marinhhs.org/surveillance'

--- a/src/shared/sources/us/ca/marin-county.js
+++ b/src/shared/sources/us/ca/marin-county.js
@@ -1,0 +1,43 @@
+const maintainers = require('../../_lib/maintainers.js')
+const arcgis = require('../../_lib/arcgis.js')
+const timeseriesFilter = require('../../_lib/timeseries-filter.js')
+
+module.exports = {
+  country: 'iso1:US',
+  state: 'iso2:US-CA',
+  county: 'fips:06041',
+
+  maintainers: [ maintainers.mnguyen ],
+
+  timeseries: true,
+  priority: 1,
+  friendly: {
+    name: 'Marin Health & Human Services',
+    url: 'https://coronavirus.marinhhs.org/surveillance'
+  },
+
+  scrapers: [
+    {
+      startDate: '2020-01-19',
+      crawl: [
+        {
+          type: 'json',
+          paginated: arcgis.paginated('https://services6.arcgis.com/T8eS7sop5hLmgRRH/ArcGIS/rest/services/Covid19_Cumulative/FeatureServer/0/query'),
+        },
+      ],
+      scrape (data, date) {
+        const toYYYYMMDD = t => new Date(t).toISOString().split('T')[0]
+        const { filterDate, func } = timeseriesFilter(data, 'Date', toYYYYMMDD, date)
+        const filteredData = data.filter(func)
+        return {
+          cases: filteredData[0].Total_Cases,
+          recovered: filteredData[0].Total_Recovered_,
+          hospitalized: parseInt(filteredData[0].Total_Hospitalized, 10),
+          deaths: parseInt(filteredData[0].Total_Deaths, 10),
+          date: filterDate,
+        }
+      }
+    },
+  ]
+
+}


### PR DESCRIPTION
Added a source for Marin County, California, that uses the following datasets from [this ArcGIS FeatureServer](https://services6.arcgis.com/T8eS7sop5hLmgRRH/ArcGIS/rest/services/Covid19_Cumulative/FeatureServer) included in [the county’s COVID-19 dashboard](https://coronavirus.marinhhs.org/surveillance#cumulative).

Unlike aggregators such as the _Mercury News_ and _New York Times_, Marin Health & Human Services excludes inmates at San Quentin State Prison, who are counted by the California Department of Corrections and Rehabilitation along with inmates at other state prisons. The county’s dashboard does include San Quentin inmates in a couple Datawrapper charts, but this data is only a mirror of [CDCR’s dashboard](https://www.cdcr.ca.gov/covid19/population-status-tracking/).

This project seems to have a preference for local government sources over statewide, aggregated sources such as the California Department of Public Health, so I think it would be appropriate to use the county’s data where possible. That said, it’s important to count these inmates _somewhere_. How are inmates in other California counties and other states being counted?

Potentially fixes #358.