### PR TITLE
Rewrite scraper for Solano County, California

### DIFF
--- a/src/shared/sources/us/ca/solano-county.js
+++ b/src/shared/sources/us/ca/solano-county.js
@@ -10,7 +10,7 @@ module.exports = {
   maintainers: [ maintainers.mnguyen ],
 
   timeseries: true,
-  priority: 1,
+  priority: 2,
   friendly: {
     name: 'Solano County Public Health',
     url: 'https://doitgis.maps.arcgis.com/apps/MapSeries/index.html?appid=055f81e9fe154da5860257e3f2489d67'


### PR DESCRIPTION
The original scrapers migrated from the Corona Data Scraper project no longer scrape anything and have long been outdated. This PR adds a replacement scraper based on [this ArcGIS FeatureServer](https://services2.arcgis.com/SCn6czzcqKAFwdGU/ArcGIS/rest/services/COVID19Surveypt1v3_view/FeatureServer/), which is featured in the county public health department’s [ArcGIS dashboard](https://doitgis.maps.arcgis.com/apps/MapSeries/index.html?appid=055f81e9fe154da5860257e3f2489d67). The dashboard has used a succession of FeatureServers; each time that it migrates to a new FeatureServer, the old one remains but no longer gets updated.

The county only issues case and death counts on weekdays; on the weekends, they only report hospitalizations. In #375, the Santa Clara County scraper can fall back to previous days to backfill missing data, but that approach gets weird in this case. The current patient count could go up without the cumulative patient count going up, and it wouldn’t be clear to clients what’s going on. So for now, this scraper returns only the current hospitalizations on weekends.