### PR TITLE
Change pagination handling to single file of results.

### DIFF
--- a/src/events/crawler/crawler/index.js
+++ b/src/events/crawler/crawler/index.js
@@ -51,15 +51,6 @@ async function client (params) {
   return response
 }
 
-// Create an async client to pass to crawl.paginated functions
-function makePaginatedClient (type, sourceCrawl) {
-  return async function paginatedClient (url, options = {}) {
-    const crawlOpts = { ...sourceCrawl, url, ...options }
-    return crawl(type, crawlOpts)
-  }
-}
-
 crawl.client = client
-crawl.makePaginatedClient = makePaginatedClient
 
 module.exports = crawl

--- a/src/events/scraper/load-cache/index.js
+++ b/src/events/scraper/load-cache/index.js
@@ -76,7 +76,7 @@ async function load (params, useS3) {
     for (const crawl of scraper.crawl) {
       // We may have multiple crawls for a single scraper (each with a unique name key)
       // Disambiguate and match them so we are getting back the correct data sources
-      const { name='default', paginated } = crawl
+      const { name='default' } = crawl
 
       const matches = parseCacheFilename.matchName(name, files)
 
@@ -89,12 +89,7 @@ async function load (params, useS3) {
       // We may have multiple files for this day, choose the last one
       const file = matches[matches.length - 1]
 
-      let fileset = [ file ]
-      if (paginated)
-        fileset = parseCacheFilename.matchPaginatedSet(file, files)
-
-      const allContent = fileset.map(file => loader.getFileContents({ _sourceKey, keys, file }))
-      crawl.pages = await Promise.all(allContent)
+      crawl.content = await loader.getFileContents({ _sourceKey, keys, file })
       cache.push(crawl)
     }
     if (cache !== 'miss') {

--- a/src/events/scraper/parse-cache/index.js
+++ b/src/events/scraper/parse-cache/index.js
@@ -19,14 +19,10 @@ module.exports = async function parseCache (cache) {
 
   const parsed = []
   for (const hit of cache) {
-    let { pages, options } = hit
-
-    const parsePromises = pages.
-          map(p => (hit.type !== 'pdf') ? p.toString() : p).
-          map(content => parse[hit.type]({ content, options }))
-    const results = await Promise.all(parsePromises)
-    const result = hit.paginated ? results : results[ 0 ]
-
+    let { content, options } = hit
+    if (hit.type !== 'pdf')
+      content = content.toString()
+    const result = await parse[hit.type]({ content, options })
     const name = hit.name || 'default'
     parsed.push({ [name]: result })
   }

--- a/src/shared/sources/_lib/validate-source.js
+++ b/src/shared/sources/_lib/validate-source.js
@@ -98,10 +98,12 @@ function validateSource (source) {
         requirement(is.string(url) || is.function(url), datedError('Crawler url must be a string or function'))
       }
       if (paginated) {
-        requirement(
-          is.function(paginated) && paginated.constructor.name === 'AsyncFunction',
-          datedError('Crawler paginated must be an async function')
-        )
+        requirement(is.string(paginated.first),
+                    datedError('Crawler paginated.first must be string'))
+        requirement(is.function(paginated.next),
+                    datedError('Crawler paginated.next must be function'))
+        requirement(is.function(paginated.records),
+                    datedError('Crawler paginated.records must be function'))
       }
 
       // Crawl name keys

--- a/src/shared/sources/jp/index.js
+++ b/src/shared/sources/jp/index.js
@@ -1,8 +1,7 @@
-const assert = require('assert')
 const maintainers = require('../_lib/maintainers.js')
 const transform = require('../_lib/transform.js')
-const datetime = require('../../datetime/index.js')
 const arcgis = require('../_lib/arcgis.js')
+const timeseriesFilter = require('../_lib/timeseries-filter.js')
 
 const country = 'iso1:JP'
 module.exports = {
@@ -21,32 +20,35 @@ module.exports = {
       crawl: [
         {
           type: 'json',
-          paginated: async client => {
-            const url = 'https://services8.arcgis.com/JdxivnCyd1rvJTrY/arcgis/rest/services/v2_covid19_list_csv/FeatureServer/0/query'
-            return arcgis.crawlPaginated(client, url)
-          }
+          paginated: arcgis.paginated('https://services8.arcgis.com/JdxivnCyd1rvJTrY/arcgis/rest/services/v2_covid19_list_csv/FeatureServer/0/query')
         }
       ],
-      scrape (pages, date, { getIso2FromName, groupBy }) {
-        let attributes = arcgis.loadPaginatedFeatures(pages).
-            map(f => f.attributes).
-            filter(i => i.Date).
-            filter(i => datetime.dateIsBeforeOrEqualTo(new Date(i.Date), date))
-        assert(attributes.length > 0, 'data fetch failed, no attributes')
+      scrape (data, date, { getIso2FromName, groupBy }) {
+        // JP reports data as epoch int
+        // e.g. 1578960000000 = 2020-01-14T00:00:00.000Z
+        // If null, assume it's 2020-01-14
+        function toYYYYMMDD (n) {
+          if (!n)
+            return '2020-01-14'
+          return new Date(n).toISOString().split('T')[0]
+        }
 
-        const groupedByState = groupBy(attributes, attribute => attribute.Prefecture)
+        const { filterDate, func } = timeseriesFilter(data, 'Date', toYYYYMMDD, date)
+        const items = data.filter(func)
+
+        const groupedByState = groupBy(items, attribute => attribute.Prefecture)
         const states = []
-        for (const [ stateName, stateAttributes ] of Object.entries(groupedByState)) {
+        for (const [ stateName, stateItems ] of Object.entries(groupedByState)) {
           states.push({
             state: getIso2FromName({ country, name: stateName }),
-            cases: stateAttributes.length
+            cases: stateItems.length,
+            date: filterDate
           })
         }
 
         const summedData = transform.sumData(states)
-        states.push(summedData)
+        states.push({ ...summedData, date: filterDate })
 
-        // console.table(states)
         return states
       }
     }

--- a/tests/unit/shared/sources/source-validation-test.js
+++ b/tests/unit/shared/sources/source-validation-test.js
@@ -49,8 +49,12 @@ test('validateSource catches problems', t => {
         crawl: [
           { type: 'text' /* bad type */,
             url: 'https://somedata.csv',
-            /* Can't have url and paginated, pag. must be async. */
-            paginated: client => { return [ client.get(123) ] }
+            /* Can't have url and paginated. */
+            paginated: {
+              a: 1,
+              b: 2,
+              c: 3
+            }
           } ],
         scrape (data) { return { cases: data.cases } }
       },
@@ -100,7 +104,9 @@ test('validateSource catches problems', t => {
     '2020-03-03: Invalid crawler.data \'trash\'; must be one of: table, list, paragraph',
     '2020-03-01: Invalid crawler.type \'text\'; must be one of: page, headless, csv, tsv, pdf, json, raw',
     '2020-03-01: Crawler must have either url or paginated, but not both',
-    '2020-03-01: Crawler paginated must be an async function',
+    '2020-03-01: Crawler paginated.first must be string',
+    '2020-03-01: Crawler paginated.next must be function',
+    '2020-03-01: Crawler paginated.records must be function',
     '2020-03-04: Multiple crawlers must have a name',
     'Scraper must contain a startDate',
     // '2020-03-02: Single crawler must not have a name key', // Not anymore.


### PR DESCRIPTION
Fix pagination to simplify it for all arcgis scrapers.  This will greatly simplify adding it to the rest of the sources.