### PR TITLE
Prioritize county dashboard scrapers over The Mercury News

### DIFF
--- a/src/shared/sources/us/ca/san-francisco-county.js
+++ b/src/shared/sources/us/ca/san-francisco-county.js
@@ -7,6 +7,7 @@ module.exports = {
   state: 'iso2:US-CA',
   county: 'fips:06075',
   timeseries: true,
+  priority: 2,
   maintainers: [ maintainers.jbencina, maintainers.mnguyen, maintainers.jzohrab ],
   friendly: {
     name: 'SF Department of Public Health',

--- a/src/shared/sources/us/ca/santa-clara-county.js
+++ b/src/shared/sources/us/ca/santa-clara-county.js
@@ -8,7 +8,7 @@ module.exports = {
   maintainers: [ maintainers.mnguyen ],
 
   timeseries: true,
-  priority: 1,
+  priority: 2,
   friendly: {
     name: 'County of Santa Clara Open Data Portal',
     url: 'https://data.sccgov.org/browse?category=COVID-19'


### PR DESCRIPTION
I just realized the _Mercury News_ scraper has a priority of 1, which is the same as the Santa Clara County scraper added in #375. That might explain why the spike in deaths in https://github.com/covidatlas/li/issues/363#issuecomment-670172011 still shows up despite there being more accurate county dashboard scrapers. This PR increases the priorities of the Santa Clara County and San Francisco scrapers above the _Mercury News_ scraper’s priority.