### PR TITLE
Remove trailing slashes in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 .arc-env
 .DS_Store
-crawler-cache/
-migrated-cache/
-node_modules/
+crawler-cache
+migrated-cache
+node_modules
 sam.json
 sam.yaml
-scratch/
+scratch
 test-results.txt
 
 # Generated reports.


### PR DESCRIPTION
My crawler-cache is a symlink to another directory, and the trailing
slash caused Git not to ignore it.