### PR TITLE
Set Content-Type headers on S3 objects

### DIFF
--- a/src/events/reports-v1/package-lock.json
+++ b/src/events/reports-v1/package-lock.json
@@ -62,6 +62,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",

--- a/src/events/reports-v1/package.json
+++ b/src/events/reports-v1/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@architect/functions": "^3.8.4",
-    "csv-stringify": "^5.5.0"
+    "csv-stringify": "^5.5.0",
+    "mime": "^2.4.6"
   }
 }

--- a/src/events/reports-v1/write/_write-s3.js
+++ b/src/events/reports-v1/write/_write-s3.js
@@ -1,4 +1,5 @@
 const aws = require('aws-sdk')
+const mime = require('mime')
 const getReportsBucket = require('@architect/shared/utils/reports-bucket.js')
 
 async function write (params) {
@@ -10,7 +11,8 @@ async function write (params) {
     ACL: 'public-read',
     Bucket,
     Key: key,
-    Body: Buffer.from(data)
+    Body: Buffer.from(data),
+    ContentType: mime.getType(filename)
   }
   const s3 = new aws.S3()
   const put = s3.putObject(putParams)

--- a/tools/geojsondb/upload-report-to-s3.js
+++ b/tools/geojsondb/upload-report-to-s3.js
@@ -16,7 +16,8 @@ async function upload (file) {
     ACL: 'public-read',
     Bucket,
     Key: key,
-    Body: Buffer.from(fs.readFileSync(file))
+    Body: Buffer.from(fs.readFileSync(file)),
+    ContentType: 'application/json'
   }
 
   console.log('Uploading ...')


### PR DESCRIPTION
Note that `s3.copyObject` should preserve metadata, so this should only be needed on
`s3.putObject`.

S3 sends everything with `Content-Type: application/octet-stream` by default:

```
$ curl -o /dev/null -D /dev/stdout -sS https://liproduction-reportsbucket-bhk8fnhv1s76.s3-us-west-1.amazonaws.com/v1/latest/locations.json | grep Content-Type
Content-Type: application/octet-stream
```

This patch sets it to `application/json` for `.json` files, and similarly for `.csv`. (Apparently you [cannot do this automatically](https://stackoverflow.com/questions/37427041/change-content-type-in-s3-bucket-policy-for-a-specific-file-extension), so it needs to be set for every S3 put request.)

I couldn't test this change since I don't have access to the S3 bucket, put I triple-checked the code to make sure it's correct, so hopefully it won't cause any problems!