### PR TITLE
Fix timeout (max is 900).

### DIFF
--- a/src/scheduled/status-slack-bot/.arc-config
+++ b/src/scheduled/status-slack-bot/.arc-config
@@ -1,4 +1,4 @@
 @aws
 runtime nodejs12.x
 memory 256
-timeout 3000
+timeout 900


### PR DESCRIPTION
Currently fails:

```
            "ResourceStatusReason": "1 validation error detected: Value '3000' at 'timeout' failed to satisfy constraint: Member must have value less than or equal to 900 (Service: AWSLambdaInternal; Status Code: 400; Error Code: ValidationException; Request ID: 1346e515-a57b-4b63-8bd4-2ff78d765ee4)",
```

Whoops, typo.