### PR TITLE
Fix getDatesRange so it works regardless of user timezone

### DIFF
--- a/src/events/regenerator/fire-events/_get-date-range.js
+++ b/src/events/regenerator/fire-events/_get-date-range.js
@@ -14,7 +14,7 @@ function throwIfNonDate (d) {
  *
  * Such a simple function, but js can make it difficult.
  */
-module.exports = function getDatesRange (earliestYYYYMMDD, latestYYYYMMDD) {
+module.exports = function getDateRange (earliestYYYYMMDD, latestYYYYMMDD) {
 
   throwIfNonDate(earliestYYYYMMDD)
   throwIfNonDate(latestYYYYMMDD)

--- a/src/events/regenerator/fire-events/_get-date-range.js
+++ b/src/events/regenerator/fire-events/_get-date-range.js
@@ -1,4 +1,4 @@
-const datetime = require('@architect/shared/datetime/index.js')
+const spacetime = require('spacetime')
 
 
 function throwIfNonDate (d) {
@@ -22,12 +22,13 @@ module.exports = function getDatesRange (earliestYYYYMMDD, latestYYYYMMDD) {
   if (earliestYYYYMMDD > latestYYYYMMDD)
     throw new Error(`${earliestYYYYMMDD} > ${latestYYYYMMDD}`)
 
-  const d = new Date(earliestYYYYMMDD)
-  const latest = new Date(latestYYYYMMDD)
+  let d = spacetime(earliestYYYYMMDD)
+  const latest = spacetime(latestYYYYMMDD)
+
   let dates = []
-  while (d <= latest) {
-    d.setDate(d.getDate() + 1)
-    dates.push(datetime.getYYYYMMDD(d))
+  while (!d.isAfter(latest)) {
+    dates.push(d.format('YYYY-MM-DD'))
+    d = d.add(1, 'day')
   }
   return dates
 }

--- a/src/events/regenerator/fire-events/index.js
+++ b/src/events/regenerator/fire-events/index.js
@@ -1,7 +1,7 @@
 const arc = require('@architect/functions')
 const sorter = require('@architect/shared/utils/sorter.js')
 const datetime = require('@architect/shared/datetime/index.js')
-const getDatesRange = require('./_get-date-range.js')
+const getDateRange = require('./_get-date-range.js')
 
 module.exports = async function fireEvents (source) {
   const { scrapers } = source
@@ -11,7 +11,7 @@ module.exports = async function fireEvents (source) {
 
   // In the future perhaps we can do something smarter than starting from startDate
   const today = new Date()
-  const dates = getDatesRange(earliest, datetime.getYYYYMMDD(today))
+  const dates = getDateRange(earliest, datetime.getYYYYMMDD(today))
 
   // The return of el cheapo queue
   let queue = 0

--- a/src/events/regenerator/package-lock.json
+++ b/src/events/regenerator/package-lock.json
@@ -95,6 +95,11 @@
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
     },
+    "spacetime": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/spacetime/-/spacetime-6.6.2.tgz",
+      "integrity": "sha512-6JmCipylm2+GcYsX8dXgPRU8EKjazSy3T8/bZDMVwJHPSEcakm4FGszlI1yN2uXIUyTlHVuyjldM7TXoKs2GRQ=="
+    },
     "tsscmp": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",

--- a/src/events/regenerator/package.json
+++ b/src/events/regenerator/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@architect/functions": "^3.8.4"
+    "@architect/functions": "^3.8.4",
+    "spacetime": "^6.6.2"
   }
 }

--- a/tests/unit/events/regenerator/fire-events/_get-date-range-test.js
+++ b/tests/unit/events/regenerator/fire-events/_get-date-range-test.js
@@ -1,9 +1,9 @@
-const getDatesRange = require('../../../../../src/events/regenerator/fire-events/_get-date-range.js')
+const getDateRange = require('../../../../../src/events/regenerator/fire-events/_get-date-range.js')
 const test = require('tape')
 
 
 test('can get range', t => {
-  const actual = getDatesRange('2020-07-11', '2020-07-15')
+  const actual = getDateRange('2020-07-11', '2020-07-15')
   const expected = []
   for (let i = 11; i <= 15; i++) expected.push(`2020-07-${i}`)
   t.deepEqual(expected, actual)
@@ -12,7 +12,7 @@ test('can get range', t => {
 
 
 test('same start and end', t => {
-  const actual = getDatesRange('2020-07-11', '2020-07-11')
+  const actual = getDateRange('2020-07-11', '2020-07-11')
   const expected = [ '2020-07-11' ]
   t.deepEqual(expected, actual)
   t.end()
@@ -20,7 +20,7 @@ test('same start and end', t => {
 
 
 test('works for daylight savings', t => {
-  const actual = getDatesRange('2020-03-06', '2020-03-12')
+  const actual = getDateRange('2020-03-06', '2020-03-12')
   const expected = []
   for (let i = 6; i <= 12; i++) expected.push(`2020-03-${('' + i).padStart(2, '0')}`)
   t.deepEqual(expected, actual)
@@ -29,7 +29,7 @@ test('works for daylight savings', t => {
 
 
 test('works at month turnover', t => {
-  const actual = getDatesRange('2020-03-29', '2020-04-02')
+  const actual = getDateRange('2020-03-29', '2020-04-02')
   const expected = [
     '2020-03-29',
     '2020-03-30',
@@ -43,7 +43,7 @@ test('works at month turnover', t => {
 
 
 test('works at year turnover', t => {
-  const actual = getDatesRange('2020-12-30', '2021-01-02')
+  const actual = getDateRange('2020-12-30', '2021-01-02')
   const expected = [
     '2020-12-30',
     '2020-12-31',
@@ -56,7 +56,7 @@ test('works at year turnover', t => {
 
 
 test('works at leap year', t => {
-  let actual = getDatesRange('2020-02-27', '2020-03-01')
+  let actual = getDateRange('2020-02-27', '2020-03-01')
   let expected = [
     '2020-02-27',
     '2020-02-28',
@@ -65,7 +65,7 @@ test('works at leap year', t => {
   ]
   t.deepEqual(expected, actual, 'leap year')
 
-  actual = getDatesRange('2021-02-27', '2021-03-01')
+  actual = getDateRange('2021-02-27', '2021-03-01')
   expected = [
     '2021-02-27',
     '2021-02-28',
@@ -78,18 +78,18 @@ test('works at leap year', t => {
 
 
 test('throws on non dates', t => {
-  t.throws(() => getDatesRange('something', 'here'))
+  t.throws(() => getDateRange('something', 'here'))
   t.end()
 })
 
 
 test('throws if earlier > later', t => {
-  t.throws(() => getDatesRange('2020-07-08', '2020-07-07'))
+  t.throws(() => getDateRange('2020-07-08', '2020-07-07'))
   t.end()
 })
 
 
 test('throws if missing date', t => {
-  t.throws(() => getDatesRange(null, '2020-07-11'))
+  t.throws(() => getDateRange(null, '2020-07-11'))
   t.end()
 })


### PR DESCRIPTION
Without this fix, I'm getting the following test failures:

```
  Failed Tests: There were 7 failures

    can get range

      ✖ should be deeply equivalent (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:9:5)


    same start and end

      ✖ should be deeply equivalent (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:17:5)


    works for daylight savings

      ✖ should be deeply equivalent (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:26:5)


    works at month turnover

      ✖ should be deeply equivalent (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:40:5)


    works at year turnover

      ✖ should be deeply equivalent (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:53:5)


    works at leap year

      ✖ leap year (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:66:5)
      ✖ non-leap year (|- not deepEqual |- at: tests/unit/events/regenerator/fire-events/_get-date-range-test.js:74:5)
```

I grepped the source to see where `getDatesRange` is used, and it turns out it's used only in one place: https://github.com/covidatlas/li/blob/487c670191800daf93e024ec0a8f39db4779686d/src/events/regenerator/fire-events/index.js#L14