### PR TITLE
Fix sortKeys helper function

### DIFF
--- a/tests/integration/events/reports-v1/index-test.js
+++ b/tests/integration/events/reports-v1/index-test.js
@@ -72,11 +72,12 @@ function assertContentsEqual (t, filename) {
   const actualFilename = join(d, 'v1', filename)
   const expectedFilename = join(__dirname, 'expected-results', filename)
 
-  function sortKeys (item) {
-    const keys = Object.keys(item).sort()
-    return keys.reduce((hsh, k) => {
-      return { ...hsh, [k]: item[k] }
-    })
+  function sortKeys(item) {
+    const ordered = {}
+    for (let key of Object.keys(item).sort()) {
+      ordered[key] = item[key]
+    }
+    return ordered
   }
 
   function clean (f) {


### PR DESCRIPTION
I noticed an issue in the test code when I was working on another patch and it reported a test failure:

<img width="835" alt="li" src="https://user-images.githubusercontent.com/524783/90696704-acb75080-e274-11ea-84fa-220efba31485.png">

I tracked this down to the `sortKeys` helper function, which this pull request fixes!

Current:

```
>   function sortKeys (item) {
...     const keys = Object.keys(item).sort()
...     return keys.reduce((hsh, k) => {
.....       return { ...hsh, [k]: item[k] }
.....     })
...   }
undefined
> sortKeys({foo: 1, bar: 2})
{ '0': 'b', '1': 'a', '2': 'r', foo: 1 }
>
```

My patch:

```
>   function sortKeys(item) {
...     const ordered = {}
...     for (let key of Object.keys(item).sort()) {
.....       ordered[key] = item[key]
.....     }
...     return ordered
...   }
undefined
> sortKeys({foo: 1, bar: 2})
{ bar: 2, foo: 1 }
>
```