### PR TITLE
Fix build.yml so we actually run on Windows and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,16 @@ name: Node CI
 # Push tests commits; pull_request tests PR merges
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   # Test the build
   build:
     # Setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [ 12.x ]
@@ -32,6 +36,11 @@ jobs:
           echo "SHA:        ${{ github.sha }}"
           VER=`node --version`; echo "Node ver:   $VER"
           VER=`npm --version`; echo "npm ver:    $VER"
+
+      - name: Set up Windows
+        run: |
+          npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
+        if: matrix.os == 'windows-latest'
 
       - name: Install
         run: npm install


### PR DESCRIPTION
Right now we just run on ubuntu-latest three times.

See for example https://github.com/covidatlas/li/commit/d06f2ea5fb0a6647ef42b818991d57e6cf29bcb9/checks#step:1:3, which has os = windows-latest, but is actually running on Ubuntu.

I'm assuming this PR will uncover some tests that'll fail on Windows or Mac, so perhaps we should hold off on merging it until those are fixed.