### PR TITLE
Run CI on ubuntu and macOS.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,13 @@ jobs:
   # Test the build
   build:
     # Setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [ 12.x ]
-        os: [ windows-latest, ubuntu-latest, macOS-latest ]
+        # Currently, windows tests fail, see https://github.com/covidatlas/li/issues/591.
+        # When that issue is resolved, we should add windows-list to the os list.
+        os: [ ubuntu-latest, macOS-latest ]
 
     # Go
     steps:


### PR DESCRIPTION
Replacement for https://github.com/covidatlas/li/pull/590.  CI passes on mac and ubuntu, and devs are only using that at the moment, so let's go with this.