### PR TITLE
Migrate Alameda County to new ArcGIS FeatureServer

### DIFF
--- a/src/shared/sources/us/ca/alameda-county.js
+++ b/src/shared/sources/us/ca/alameda-county.js
@@ -22,38 +22,17 @@ module.exports = {
         {
           type: 'json',
           name: 'base',
-          paginated: arcgis.paginated('https://services3.arcgis.com/1iDJcsklY3l3KIjE/arcgis/rest/services/AC_dates2/FeatureServer/0/query'),
-        },
-        {
-          type: 'json',
-          name: 'hospitalizations',
-          paginated: arcgis.paginated('https://services3.arcgis.com/1iDJcsklY3l3KIjE/arcgis/rest/services/AC_hospitalized2/FeatureServer/0/query'),
-        },
-        {
-          type: 'json',
-          name: 'tests',
-          paginated: arcgis.paginated('https://services3.arcgis.com/1iDJcsklY3l3KIjE/arcgis/rest/services/AC_testing_dates2/FeatureServer/0/query'),
+          paginated: arcgis.paginated('https://services5.arcgis.com/ROBnTHSNjoZ2Wm1P/arcgis/rest/services/COVID_19_Statistics/FeatureServer/4/query'),
         },
       ],
-      scrape ({ base, hospitalizations, tests }, date) {
+      scrape (base, date) {
         var result = {}
         const timestampToISO = t => new Date(t).toISOString().split('T')[0]
 
-        const datedBase = base.filter(f => date === timestampToISO(f.Date))
+        const datedBase = base.filter(f => date === timestampToISO(f.dtcreate))
         if (datedBase.length !== 0) {
-          result.cases = datedBase[0].AC_CumulCases
-          result.deaths = datedBase[0].AC_CumulDeaths
-        }
-
-        const datedHospitalizations = hospitalizations.filter(f => date === timestampToISO(f.Date))
-        if (datedHospitalizations.length !== 0) {
-          result.hospitalized_current = datedHospitalizations[0].Hospitalized_COVID_19_Positive_
-          result.icu_current = datedHospitalizations[0].ICU_COVID_19_Positive_Patients
-        }
-
-        const datedTests = tests.filter(f => date === timestampToISO(f.Date))
-        if (datedTests.length !== 0) {
-          result.tested = datedTests[0].AC_Tests
+          result.cases = parseInt(datedBase[0].Alameda_County__Cumulative, 10)
+          result.deaths = parseInt(datedBase[0].Alameda_County_Deaths__Cumulati, 10)
         }
 
         if (Object.keys(result).length === 0) {


### PR DESCRIPTION
## Summary

Updated the Alameda County, California, scraper to scrape [the new FeatureServer](https://data.acgov.org/datasets/5d6bf4760af64db48b6d053e7569a47b_4) that’s currently being updated.

Fixes #562.

## Changes

This change removes the hospitalization and testing data, since those FeatureServers have been discontinued, but keeps the code’s structure in place in case the county restores those datasets.

## Additional notes

The county also publishes a more detailed [time series of cases and deaths by city and ZIP code](https://data.acgov.org/datasets/5d6bf4760af64db48b6d053e7569a47b_3), but this scraper doesn’t use that FeatureServer because the Li report structure doesn’t currently support it.