### PR TITLE
Fix link syntax in "sources" doc

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -12,7 +12,7 @@ Live sources are in `src/shared/sources/` as well.
 
 ## Criteria for sources
 
-See [./source-criteria.md](Source criteria) to determine if a source should be included in this project.
+See [Source criteria](./source-criteria.md) to determine if a source should be included in this project.
 
 ## Writing a source
 


### PR DESCRIPTION
## Summary

This is a pretty quick fix. A link on the `docs/sources.md` page wasn't rendering correctly because the syntax was backward.